### PR TITLE
Sketch out npu.configure op with ctrl pkt config

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -8,7 +8,7 @@ inputs:
   DEBUG_OS:
     description: 'which runner os to run the tmate action in (if the tmate action is run)'
     required: false
-    default: 'windows-2019'
+    default: 'windows-2022'
   DEBUG_ARCH:
     description: 'which runner arch to run the tmate action in (if the tmate action is run)'
     required: false
@@ -42,16 +42,16 @@ runs:
         detached: ${{ inputs.DEBUG_DETACHED }}
 
     - uses: ilammy/msvc-dev-cmd@v1.4.1
-      if: ${{ inputs.MATRIX_OS == 'windows-2019' }}
+      if: ${{ inputs.MATRIX_OS == 'windows-2022' }}
 
     - name: Set up Visual Studio shell
-      if: ${{ inputs.MATRIX_OS == 'windows-2019' }}
+      if: ${{ inputs.MATRIX_OS == 'windows-2022' }}
       uses: egor-tensin/vs-shell@v2
       with:
         arch: x64
 
     - name: MS Build
-      if: ${{ inputs.MATRIX_OS == 'windows-2019' }}
+      if: ${{ inputs.MATRIX_OS == 'windows-2022' }}
       uses: microsoft/setup-msbuild@v1.1
 
     - name: Free disk space
@@ -67,7 +67,7 @@ runs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install Ninja
       uses: llvm/actions/install-ninja@6a57890d0e3f9f35dfc72e7e48bc5e1e527cdd6c # Jan 17
@@ -103,7 +103,7 @@ runs:
     # do we hit that during anything we're doing here? during the linking phase of MLIR-C.dll, which links together
     # absolutely all the libs in MLIR using their full/abs paths.
     - run: echo "TEMP=$env:USERPROFILE\AppData\Local\Temp" >> $env:GITHUB_ENV
-      if: ${{ inputs.MATRIX_OS == 'windows-2019' }}
+      if: ${{ inputs.MATRIX_OS == 'windows-2022' }}
       shell: pwsh
 
     - run: echo "TEMP=/tmp" >> $GITHUB_ENV
@@ -116,7 +116,7 @@ runs:
       working-directory: ${{ env.TEMP }}
       run: |
         
-        if [ x"${{ inputs.MATRIX_OS }}" == x"windows-2019" ]; then
+        if [ x"${{ inputs.MATRIX_OS }}" == x"windows-2022" ]; then
           WORKSPACE_ROOT="/C/a"
         else
           WORKSPACE_ROOT=$GITHUB_WORKSPACE
@@ -130,7 +130,7 @@ runs:
         git clone --recursive -b ${{ github.head_ref || github.ref_name }} https://github.com/${{ github.repository }}.git "$WORKSPACE_ROOT"
         ls "$WORKSPACE_ROOT"
         
-        if [ x"${{ inputs.MATRIX_OS }}" == x"windows-2019" ]; then
+        if [ x"${{ inputs.MATRIX_OS }}" == x"windows-2022" ]; then
           WORKSPACE_ROOT="C:\a"
         fi
         

--- a/.github/workflows/mlirDistro.yml
+++ b/.github/workflows/mlirDistro.yml
@@ -14,7 +14,7 @@ on:
       DEBUG_OS:
         description: 'which runner os to run the tmate action in (if the tmate action is run)'
         type: string
-        default: 'windows-2019'
+        default: 'windows-2022'
         required: false
       DEBUG_ARCH:
         description: 'which runner arch to run the tmate action in (if the tmate action is run)'
@@ -96,17 +96,9 @@ jobs:
             ARCH: aarch64
             ENABLE_RTTI: ON
 
-          - OS: windows-2019
+          - OS: windows-2022
             ARCH: AMD64
             ENABLE_RTTI: ON
-
-          # - OS: macos-12
-          #   ARCH: x86_64
-          #   ENABLE_RTTI: ON
-
-          # - OS: macos-12
-          #   ARCH: arm64
-          #   ENABLE_RTTI: ON
 
           - OS: ubuntu-22.04
             ARCH: x86_64
@@ -116,17 +108,9 @@ jobs:
             ARCH: aarch64
             ENABLE_RTTI: OFF
 
-          - OS: windows-2019
+          - OS: windows-2022
             ARCH: AMD64
             ENABLE_RTTI: OFF
-
-          # - OS: macos-12
-          #   ARCH: x86_64
-          #   ENABLE_RTTI: OFF
-
-          # - OS: macos-12
-          #   ARCH: arm64
-          #   ENABLE_RTTI: OFF
 
     steps:
 
@@ -140,13 +124,6 @@ jobs:
         fi
         echo "PIP_FIND_LINKS=$PIP_FIND_LINKS_URL" | tee -a $GITHUB_ENV
         echo "ENABLE_RTTI=${{ matrix.ENABLE_RTTI }}" | tee -a $GITHUB_ENV
-
-    - name: set ENV macos
-      if: contains(matrix.OS, 'macos')
-      shell: bash
-      run: |
-        
-        echo "OSX_VERSION=$(sw_vers -productVersion)" | tee -a $GITHUB_ENV
 
     - name: Checkout actions
       uses: actions/checkout@v4
@@ -174,6 +151,10 @@ jobs:
         MATRIX_ARCH: ${{ matrix.ARCH }}
         EXTRA_KEY: mlir-distro-enable-rtti-${{ matrix.ENABLE_RTTI }}
 
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
     # default workspace is repo root but we're not build mlir-aie here, we're building llvm+mlir
     # and thus llvm-project needs to be adjacent to utils/mlir_wheels/setup.py
     - name: Shift workspace root
@@ -184,7 +165,7 @@ jobs:
         
         ls "${{ steps.setup_base.outputs.WORKSPACE_ROOT }}"
         
-        if [ x"${{ matrix.OS }}" == x"windows-2019" ]; then
+        if [ x"${{ matrix.OS }}" == x"windows-2022" ]; then
           WORKSPACE_ROOT="${{ steps.setup_base.outputs.WORKSPACE_ROOT }}\utils\mlir_wheels"
         else
           WORKSPACE_ROOT="${{ steps.setup_base.outputs.WORKSPACE_ROOT }}/utils/mlir_wheels"
@@ -295,22 +276,22 @@ jobs:
     # python version. With py3-none you can pip install them in any python venv. Unfortunately though this does
     # mean that the python bindings themselves will confusingly not work in other envs (!=3.10)
     - name: rename non-windows
-      if: ${{ matrix.OS == 'ubuntu-22.04' || matrix.OS == 'macos-12' || matrix.OS == 'macos-14' }}
+      if: ${{ matrix.OS == 'ubuntu-22.04' }}
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       shell: bash
       run: |
         
-        rename 's/cp310-cp310/py3-none/' wheelhouse/mlir*whl
+        rename 's/cp312-cp312/py3-none/' wheelhouse/mlir*whl
         
         if [ x"${{ matrix.OS }}" == x"ubuntu-22.04" ] && [ x"${{ matrix.ARCH }}" == x"aarch64" ]; then
           rename 's/x86_64/aarch64/' wheelhouse/mlir*whl
         fi
 
     - name: rename windows
-      if: ${{ matrix.OS == 'windows-2019' }}
+      if: ${{ matrix.OS == 'windows-2022' }}
       working-directory: ${{ steps.workspace_root.outputs.WORKSPACE_ROOT }}
       run: |
-        ls wheelhouse/mlir*whl | Rename-Item -NewName {$_ -replace 'cp310-cp310', 'py3-none' }
+        ls wheelhouse/mlir*whl | Rename-Item -NewName {$_ -replace 'cp312-cp312', 'py3-none' }
 
     # The "native tools" MLIR utilities that are necessary for cross-compiling MLIR - basically just tblgen.
     # Now if you build a whole distro you naturally do get those utilities but it's easier to just bundle them
@@ -322,9 +303,10 @@ jobs:
       shell: bash
       id: build_native_tools_wheel
       run: |
-        
+        pip install setuptools
+
         for TOOL in "llvm-tblgen" "mlir-tblgen" "mlir-linalg-ods-yaml-gen" "mlir-pdll" "llvm-config" "FileCheck"; do
-          if [ x"${{ matrix.OS }}" == x"windows-2019" ]; then
+          if [ x"${{ matrix.OS }}" == x"windows-2022" ]; then
             TOOL="$TOOL.exe"
           fi
           unzip -j wheelhouse/mlir*whl "mlir/bin/$TOOL" -d native_tools/
@@ -332,11 +314,7 @@ jobs:
         
         if [ x"${{ matrix.OS }}" == x"ubuntu-22.04" ]; then
           PLAT="linux"
-        elif [ x"${{ matrix.OS }}" == x"macos-12" ]; then
-          PLAT="macosx_12_0"
-        elif [ x"${{ matrix.OS }}" == x"macos-14" ]; then
-          PLAT="macosx_14_0"
-        elif [ x"${{ matrix.OS }}" == x"windows-2019" ]; then
+        elif [ x"${{ matrix.OS }}" == x"windows-2022" ]; then
           PLAT="win"
         fi
         
@@ -374,25 +352,17 @@ jobs:
             ARCH: x86_64
             ENABLE_RTTI: ON
 
-          - OS: windows-2019
+          - OS: windows-2022
             ARCH: AMD64
             ENABLE_RTTI: ON
-
-          # - OS: macos-12
-          #   ARCH: x86_64
-          #   ENABLE_RTTI: ON
 
           - OS: ubuntu-22.04
             ARCH: x86_64
             ENABLE_RTTI: OFF
 
-          - OS: windows-2019
+          - OS: windows-2022
             ARCH: AMD64
             ENABLE_RTTI: OFF
-
-          # - OS: macos-12
-          #   ARCH: x86_64
-          #   ENABLE_RTTI: OFF
 
     steps:
       - uses: actions/download-artifact@v4
@@ -402,7 +372,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: test
         shell: bash
@@ -434,17 +404,9 @@ jobs:
             ARCH: aarch64
             ENABLE_RTTI: ON
 
-          - OS: windows-2019
+          - OS: windows-2022
             ARCH: AMD64
             ENABLE_RTTI: ON
-
-          # - OS: macos-12
-          #   ARCH: x86_64
-          #   ENABLE_RTTI: ON
-
-          # - OS: macos-12
-          #   ARCH: arm64
-          #   ENABLE_RTTI: ON
 
           - OS: ubuntu-22.04
             ARCH: x86_64
@@ -454,17 +416,9 @@ jobs:
             ARCH: aarch64
             ENABLE_RTTI: OFF
 
-          - OS: windows-2019
+          - OS: windows-2022
             ARCH: AMD64
             ENABLE_RTTI: OFF
-
-          # - OS: macos-12
-          #   ARCH: x86_64
-          #   ENABLE_RTTI: OFF
-
-          # - OS: macos-12
-          #   ARCH: arm64
-          #   ENABLE_RTTI: OFF
 
     permissions:
       id-token: write

--- a/include/aie/Dialect/AIEX/IR/AIEX.td
+++ b/include/aie/Dialect/AIEX/IR/AIEX.td
@@ -819,6 +819,16 @@ def AIE_NpuControlPacketOp: AIEX_Op<"control_packet", []> {
   }];
 }
 
+def AIE_NpuConfigureOp: AIEX_Op<"npu.configure", []> {
+  let summary = "Configure NPU operation";
+  let arguments = (ins );
+  let results = (outs );
+  let assemblyFormat = [{ attr-dict }];
+  let description = [{
+    This operation is used to configure the NPU.
+  }];
+}
+
 // NPU Bd Write operation
 def AIE_NpuWriteBdOp: AIEX_Op<"npu.writebd", []> {
   let summary = "dma operator";

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -213,9 +213,7 @@ emitTransactionOps(OpBuilder &builder,
   auto loc = builder.getUnknownLoc();
 
   // create the txn ops
-  for (auto p : llvm::zip(operations, global_data)) {
-    auto op = std::get<0>(p);
-    memref::GlobalOp payload = std::get<1>(p);
+  for (auto [op, payload] : llvm::zip(operations, global_data)) {
 
     if (op.cmd.Opcode == XAie_TxnOpcode::XAIE_IO_WRITE) {
       builder.create<AIEX::NpuWrite32Op>(loc, op.cmd.RegOff, op.cmd.Value,
@@ -249,9 +247,7 @@ emitControlPacketOps(OpBuilder &builder,
   auto ctx = builder.getContext();
 
   // create the control packet ops
-  for (auto p : llvm::zip(operations, global_data)) {
-    auto op = std::get<0>(p);
-    memref::GlobalOp payload = std::get<1>(p);
+  for (auto [op, payload] : llvm::zip(operations, global_data)) {
 
     if (op.cmd.Opcode == XAie_TxnOpcode::XAIE_IO_WRITE) {
       builder.create<AIEX::NpuControlPacketOp>(
@@ -260,10 +256,10 @@ emitControlPacketOps(OpBuilder &builder,
           /*stream_id*/ builder.getI32IntegerAttr(0),
           DenseI32ArrayAttr::get(ctx, ArrayRef<int32_t>(op.cmd.Value)));
     } else if (op.cmd.Opcode == XAie_TxnOpcode::XAIE_IO_BLOCKWRITE) {
-      if (!std::get<1>(p).getInitialValue())
+      if (!payload.getInitialValue())
         continue;
       auto blockWriteData =
-          dyn_cast<DenseIntElementsAttr>(*std::get<1>(p).getInitialValue());
+          dyn_cast<DenseIntElementsAttr>(*payload.getInitialValue());
       if (!blockWriteData) {
         payload.emitError(
             "Global symbol initial value is not a dense int array");
@@ -377,17 +373,28 @@ static LogicalResult convertTransactionOpsToMLIR(
     global_data.push_back(global);
   }
 
-  // create aiex.runtime_sequence
-  int id = 0;
-  std::string seq_name = "configure";
-  while (device.lookupSymbol(seq_name))
-    seq_name = "configure" + std::to_string(id++);
-  StringAttr seq_sym_name = builder.getStringAttr(seq_name);
-  auto seq = builder.create<AIEX::RuntimeSequenceOp>(loc, seq_sym_name);
-  seq.getBody().push_back(new Block);
+  // search for npu.configure ops in runtime sequences by walking the device
+  // and collect them in a vector.
+  SmallVector<AIEX::NpuConfigureOp> configureOps;
+  device.walk([&](AIEX::NpuConfigureOp op) { configureOps.push_back(op); });
+
+  if (configureOps.empty()) {
+
+    // create aiex.runtime_sequence
+    int id = 0;
+    std::string seq_name = "configure";
+    while (device.lookupSymbol(seq_name))
+      seq_name = "configure" + std::to_string(id++);
+    StringAttr seq_sym_name = builder.getStringAttr(seq_name);
+    auto seq = builder.create<AIEX::RuntimeSequenceOp>(loc, seq_sym_name);
+    seq.getBody().push_back(new Block);
+
+    builder.setInsertionPointToStart(&seq.getBody().front());
+  } else {
+    builder.setInsertionPoint(configureOps.front());
+  }
 
   // create the txn ops
-  builder.setInsertionPointToStart(&seq.getBody().front());
   if (outputType == OutputType::Transaction) {
     if (failed(emitTransactionOps(builder, operations, global_data)))
       return failure();
@@ -395,7 +402,7 @@ static LogicalResult convertTransactionOpsToMLIR(
     if (failed(emitControlPacketOps(builder, operations, global_data)))
       return failure();
     // resolve mask writes; control packet doesn't natively support mask write.
-    if (failed(orConsecutiveWritesOnSameAddr(&seq.getBody().front())))
+    if (failed(orConsecutiveWritesOnSameAddr(builder.getBlock())))
       return failure();
   } else {
     llvm_unreachable("bad output type");

--- a/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
@@ -14,6 +14,7 @@
 #include "aie/Dialect/AIEX/Transforms/AIEXPasses.h"
 
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/IRMapping.h"
 #include "mlir/Pass/Pass.h"
 
 #include "llvm/ADT/TypeSwitch.h"
@@ -73,6 +74,8 @@ struct AIECtrlPacketToDmaPass : AIECtrlPacketToDmaBase<AIECtrlPacketToDmaPass> {
 
       OpBuilder builder(f);
 
+      IRMapping mapping;
+
       auto newSeq =
           builder.create<AIEX::RuntimeSequenceOp>(loc, f.getSymNameAttr());
       newSeq.getBody().push_back(new Block);
@@ -81,13 +84,22 @@ struct AIECtrlPacketToDmaPass : AIECtrlPacketToDmaBase<AIECtrlPacketToDmaPass> {
       auto ctrlPktMemrefType = MemRefType::get(
           ShapedType::kDynamic, IntegerType::get(ctx, 32), nullptr, 0);
       auto newBlockArg = newSeq.getBody().addArgument(ctrlPktMemrefType, loc);
+      // Copy the arguments from the old sequence to the new one.
+      for (auto arg : f.getBody().getArguments()) {
+        // Add the argument to the new sequence.
+        auto newArg = newSeq.getBody().addArgument(arg.getType(), arg.getLoc());
+        // Replace all uses of the old argument with the new one.
+        arg.replaceAllUsesWith(newArg);
+        // Add the mapping for the argument.
+        mapping.map(arg, newArg);
+      }
       builder.setInsertionPointToStart(&newSeq.getBody().front());
 
       int ddrOffset = 0;
       Block &entry = f.getBody().front();
       for (auto &o : entry) {
-        llvm::TypeSwitch<Operation *>(&o).Case<NpuControlPacketOp>(
-            [&](auto op) {
+        llvm::TypeSwitch<Operation *>(&o)
+            .Case<NpuControlPacketOp>([&](auto op) {
               // Destination tile info
               int col = op.getColumnFromAddr();
               int row = op.getRowFromAddr();
@@ -139,6 +151,10 @@ struct AIECtrlPacketToDmaPass : AIECtrlPacketToDmaBase<AIECtrlPacketToDmaPass> {
               auto row_num = builder.getI32IntegerAttr(1);
               builder.create<AIEX::NpuSyncOp>(loc, shimCol, shimRow, dir, chan,
                                               col_num, row_num);
+            })
+            .Default([&](Operation *op) {
+              // For all other operations, just clone them to the new sequence.
+              builder.clone(*op, mapping);
             });
       }
 

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -679,7 +679,7 @@ class FlowRunner:
                     "aie-translate",
                     "-aie-ctrlpkt-to-bin",
                     "-aie-sequence-name",
-                    "configure",
+                    "run",
                     self.prepend_tmp("ctrlpkt.mlir"),
                     "-o",
                     "ctrlpkt.bin",
@@ -698,14 +698,14 @@ class FlowRunner:
                     "aie-translate",
                     "-aie-npu-to-binary",
                     "-aie-sequence-name",
-                    "configure",
+                    "run",
                     self.prepend_tmp("ctrlpkt_dma_seq.mlir"),
                     "-o",
                     "ctrlpkt_dma_seq.bin",
                 ],
             )
             await self.aiebu_asm(
-                "ctrlpkt_dma_seq.bin", "ctrlpkt_dma_seq.elf", "ctrlpkt.bin"
+                "ctrlpkt_dma_seq.bin", opts.elf_name, "ctrlpkt.bin"
             )
 
     async def process_elf(self, module_str):
@@ -1362,7 +1362,7 @@ class FlowRunner:
             if opts.ctrlpkt and opts.execute:
                 processes.append(self.process_ctrlpkt(input_physical_str))
 
-            if opts.elf and opts.execute:
+            if opts.elf and not opts.ctrlpkt and opts.execute:
                 processes.append(self.process_elf(input_physical_str))
 
             await asyncio.gather(*processes)

--- a/python/compiler/aiecc/main.py
+++ b/python/compiler/aiecc/main.py
@@ -613,6 +613,56 @@ class FlowRunner:
                 print(f"copy {tmp} to {opts.txn_name}")
             shutil.copy(tmp, opts.txn_name)
 
+    async def aiebu_asm(self, input_file, output_file, ctrl_packet_file=None):
+
+        # find aiebu-asm binary
+        asm_bin = "aiebu-asm"
+        if shutil.which(asm_bin) is None:
+            asm_bin = os.path.join("/", "opt", "xilinx", "aiebu", "bin", "aiebu-asm")
+            if shutil.which(asm_bin) is None:
+                asm_bin = None
+
+        if asm_bin is None:
+            print(
+                "Error: aiebu-asm not found, generation of ELF file failed.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        args = [
+            asm_bin,
+            "-t",
+            "aie2txn",
+            "-c",
+            input_file,
+            "-o",
+            output_file,
+        ]
+
+        if ctrl_packet_file:
+            ctrl_packet_size = os.path.getsize(ctrl_packet_file)
+            exteral_buffers_json = {
+                "external_buffers": {
+                    "buffer_ctrl": {
+                        "xrt_id": 0,
+                        "logical_id": -1,
+                        "size_in_bytes": ctrl_packet_size,
+                        "ctrl_pkt_buffer": 1,
+                        "name": "runtime_control_packet",
+                    },
+                }
+            }
+            with open(self.prepend_tmp("external_buffers.json"), "w") as f:
+                json.dump(exteral_buffers_json, f, indent=2)
+            args = args + [
+                "-j",
+                self.prepend_tmp("external_buffers.json"),
+                "-p",
+                ctrl_packet_file,
+            ]
+
+        await self.do_call(None, args)
+
     async def process_ctrlpkt(self, module_str):
         with Context(), Location.unknown():
             run_passes(
@@ -622,6 +672,40 @@ class FlowRunner:
                 module_str,
                 self.prepend_tmp("ctrlpkt.mlir"),
                 self.opts.verbose,
+            )
+            await self.do_call(
+                None,
+                [
+                    "aie-translate",
+                    "-aie-ctrlpkt-to-bin",
+                    "-aie-sequence-name",
+                    "configure",
+                    self.prepend_tmp("ctrlpkt.mlir"),
+                    "-o",
+                    "ctrlpkt.bin",
+                ],
+            )
+            ctrlpkt_mlir_str = await read_file_async(self.prepend_tmp("ctrlpkt.mlir"))
+            run_passes(
+                "builtin.module(aie.device(aie-ctrl-packet-to-dma,aie-dma-to-npu))",
+                ctrlpkt_mlir_str,
+                self.prepend_tmp("ctrlpkt_dma_seq.mlir"),
+                self.opts.verbose,
+            )
+            await self.do_call(
+                None,
+                [
+                    "aie-translate",
+                    "-aie-npu-to-binary",
+                    "-aie-sequence-name",
+                    "configure",
+                    self.prepend_tmp("ctrlpkt_dma_seq.mlir"),
+                    "-o",
+                    "ctrlpkt_dma_seq.bin",
+                ],
+            )
+            await self.aiebu_asm(
+                "ctrlpkt_dma_seq.bin", "ctrlpkt_dma_seq.elf", "ctrlpkt.bin"
             )
 
     async def process_elf(self, module_str):
@@ -644,32 +728,7 @@ class FlowRunner:
         with open(npu_insts_bin, "wb") as f:
             f.write(struct.pack("I" * len(npu_insts), *npu_insts))
 
-        # find aiebu-asm binary
-        asm_bin = "aiebu-asm"
-        if shutil.which(asm_bin) is None:
-            asm_bin = os.path.join("/", "opt", "xilinx", "aiebu", "bin", "aiebu-asm")
-            if shutil.which(asm_bin) is None:
-                asm_bin = None
-
-        if asm_bin is None:
-            print(
-                "Error: aiebu-asm not found, generation of ELF file failed.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        await self.do_call(
-            None,
-            [
-                asm_bin,
-                "-t",
-                "aie2txn",
-                "-c",
-                npu_insts_bin,
-                "-o",
-                opts.elf_name,
-            ],
-        )
+        await self.aiebu_asm(npu_insts_bin, opts.elf_name)
 
     async def process_pdi_gen(self):
 

--- a/test/npu-xrt/ctrl_packet_reconfig/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig/test.cpp
@@ -73,9 +73,9 @@ int main(int argc, const char *argv[]) {
   auto bo_instr2 = xrt::bo(device, instr2_v.size() * sizeof(int),
                            XCL_BO_FLAGS_CACHEABLE, kernel.group_id(1));
   auto bo_inA = xrt::bo(device, IN_SIZE * sizeof(IN_DATATYPE),
-                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
-  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(OUT_DATATYPE),
                         XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
+  auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(OUT_DATATYPE),
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
   auto bo_ctrlpkt = xrt::bo(device, ctrlPackets.size() * sizeof(int32_t),
                             XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
 
@@ -112,20 +112,14 @@ int main(int argc, const char *argv[]) {
   run0.set_arg(1, bo_instr3);
   run0.set_arg(2, instr3_cfg_v.size());
   run0.set_arg(3, bo_ctrlpkt);
-  run0.set_arg(4, 0);
-  run0.set_arg(5, 0);
-  run0.set_arg(6, 0);
-  run0.set_arg(7, 0);
   // Run 1: the design
   auto run1 = xrt::run(kernel);
   run1.set_arg(0, opcode);
   run1.set_arg(1, bo_instr2);
   run1.set_arg(2, instr2_v.size());
-  run1.set_arg(3, bo_inA);
-  run1.set_arg(4, 0);
+  run1.set_arg(3, 0);
+  run1.set_arg(4, bo_inA);
   run1.set_arg(5, bo_out);
-  run1.set_arg(6, 0);
-  run1.set_arg(7, 0);
 
   // Executing and waiting on the runlist
   runlist.add(run0);

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/aie2.mlir
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/aie2.mlir
@@ -284,14 +284,14 @@ module {
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
     aie.shim_dma_allocation @objFifo_out0(S2MM, 0, 0)
 
-    aiex.runtime_sequence @run(%arg0: memref<4x64x64xi8>, %arg1: memref<32xi8>, %arg2: memref<4x64x64xi8>) {
+    aiex.runtime_sequence @run(%arg0: memref<4x64x64xi8>, %arg1: memref<4x64x64xi8>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c4_i64 = arith.constant 4 : i64
       %c4096_i64 = arith.constant 4096 : i64
       %c64_i64 = arith.constant 64 : i64
       aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c4_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64], packet = <pkt_id = 0, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<4x64x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c4_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<4x64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c4_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<4x64x64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
   }

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/run.lit
@@ -4,15 +4,10 @@
 // REQUIRES: ryzen_ai_npu1
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie1.mlir -o aie1_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --xclbin-name=aie1.xclbin aie1_overlay.mlir
+// RUN: %python aiecc.py --aie-generate-xclbin --xclbin-name=aie1.xclbin aie1_overlay.mlir
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu-insts --no-compile-host --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
-//
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
-//
-// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
+// RUN: %python aiecc.py --aie-generate-ctrlpkt --aie-generate-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig_1x4_cores/test.cpp
@@ -71,7 +71,7 @@ int main(int argc, const char *argv[]) {
   auto bo_inA = xrt::bo(device, IN_SIZE * sizeof(IN_DATATYPE),
                         XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
   auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(OUT_DATATYPE),
-                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
 
   IN_DATATYPE *bufInA = bo_inA.map<IN_DATATYPE *>();
   std::vector<IN_DATATYPE> srcVecA;
@@ -105,20 +105,13 @@ int main(int argc, const char *argv[]) {
   run0.set_arg(1, bo_ctrlpkt_instr);
   run0.set_arg(2, ctrlpkt_instr_v.size());
   run0.set_arg(3, bo_ctrlpkt);
-  run0.set_arg(4, 0);
-  run0.set_arg(5, 0);
-  run0.set_arg(6, 0);
-  run0.set_arg(7, 0);
   // Run 1: the design
   auto run1 = xrt::run(kernel);
   run1.set_arg(0, opcode);
   run1.set_arg(1, bo_instr);
   run1.set_arg(2, instr_v.size());
   run1.set_arg(3, bo_inA);
-  run1.set_arg(4, 0);
-  run1.set_arg(5, bo_out);
-  run1.set_arg(6, 0);
-  run1.set_arg(7, 0);
+  run1.set_arg(4, bo_out);
 
   // Executing and waiting on the runlist
   runlist.add(run0);

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/aie2.mlir
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/aie2.mlir
@@ -247,7 +247,7 @@ module {
     aie.shim_dma_allocation @shim_out_2(S2MM, 0, 2)
     aie.shim_dma_allocation @shim_out_3(S2MM, 0, 3)
 
-    aiex.runtime_sequence @run(%arg0: memref<4x64x64xi8>, %arg1: memref<32xi8>, %arg2: memref<4x64x64xi8>) {
+    aiex.runtime_sequence @run(%arg0: memref<4x64x64xi8>, %arg1: memref<4x64x64xi8>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c2_i64 = arith.constant 2 : i64
@@ -260,10 +260,10 @@ module {
       aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c2_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 2 : i64, metadata = @shim_in_2} : memref<4x64x64xi8>
       aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c3_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64], packet = <pkt_id = 1, pkt_type = 0>) {id = 3 : i64, metadata = @shim_in_3} : memref<4x64x64xi8>
 
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 4 : i64, metadata = @shim_out_0, issue_token = true} : memref<4x64x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c1_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 5 : i64, metadata = @shim_out_1, issue_token = true} : memref<4x64x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c2_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 6 : i64, metadata = @shim_out_2, issue_token = true} : memref<4x64x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c3_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 7 : i64, metadata = @shim_out_3, issue_token = true} : memref<4x64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 4 : i64, metadata = @shim_out_0, issue_token = true} : memref<4x64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c1_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 5 : i64, metadata = @shim_out_1, issue_token = true} : memref<4x64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c2_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 6 : i64, metadata = @shim_out_2, issue_token = true} : memref<4x64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c3_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c4096_i64, %c64_i64, %c1_i64]) {id = 7 : i64, metadata = @shim_out_3, issue_token = true} : memref<4x64x64xi8>
       aiex.npu.dma_wait { symbol = @shim_out_0 }
       aiex.npu.dma_wait { symbol = @shim_out_1 }
       aiex.npu.dma_wait { symbol = @shim_out_2 }

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/run.lit
@@ -4,15 +4,10 @@
 // REQUIRES: ryzen_ai_npu1
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie1.mlir -o aie1_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-xclbin --no-compile-host --xclbin-name=aie1.xclbin aie1_overlay.mlir
+// RUN: %python aiecc.py --aie-generate-xclbin --xclbin-name=aie1.xclbin aie1_overlay.mlir
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
-// RUN: %python aiecc.py --no-aiesim --aie-generate-ctrlpkt --aie-generate-npu-insts --no-compile-host --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
-//
-// RUN: aie-translate -aie-ctrlpkt-to-bin -aie-sequence-name=configure aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt.bin
-//
-// RUN: aie-opt -aie-ctrl-packet-to-dma -aie-dma-to-npu aie2_overlay.mlir.prj/ctrlpkt.mlir -o ctrlpkt_dma_seq.mlir
-// RUN: aie-translate -aie-npu-to-binary -aie-sequence-name=configure ctrlpkt_dma_seq.mlir -o ctrlpkt_dma_seq.bin
+// RUN: %python aiecc.py --aie-generate-ctrlpkt --aie-generate-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig_4x1_cores/test.cpp
@@ -71,7 +71,7 @@ int main(int argc, const char *argv[]) {
   auto bo_inA = xrt::bo(device, IN_SIZE * sizeof(IN_DATATYPE),
                         XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(3));
   auto bo_out = xrt::bo(device, OUT_SIZE * sizeof(OUT_DATATYPE),
-                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(5));
+                        XRT_BO_FLAGS_HOST_ONLY, kernel.group_id(4));
 
   IN_DATATYPE *bufInA = bo_inA.map<IN_DATATYPE *>();
   std::vector<IN_DATATYPE> srcVecA;
@@ -105,20 +105,13 @@ int main(int argc, const char *argv[]) {
   run0.set_arg(1, bo_ctrlpkt_instr);
   run0.set_arg(2, ctrlpkt_instr_v.size());
   run0.set_arg(3, bo_ctrlpkt);
-  run0.set_arg(4, 0);
-  run0.set_arg(5, 0);
-  run0.set_arg(6, 0);
-  run0.set_arg(7, 0);
   // Run 1: the design
   auto run1 = xrt::run(kernel);
   run1.set_arg(0, opcode);
   run1.set_arg(1, bo_instr);
   run1.set_arg(2, instr_v.size());
   run1.set_arg(3, bo_inA);
-  run1.set_arg(4, 0);
-  run1.set_arg(5, bo_out);
-  run1.set_arg(6, 0);
-  run1.set_arg(7, 0);
+  run1.set_arg(4, bo_out);
 
   // Executing and waiting on the runlist
   runlist.add(run0);

--- a/test/npu-xrt/ctrl_packet_reconfig_elf/aie1.mlir
+++ b/test/npu-xrt/ctrl_packet_reconfig_elf/aie1.mlir
@@ -1,0 +1,17 @@
+//===- aie1.mlir -----------------------------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+module {
+  aie.device(npu1_1col) {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_1 = aie.tile(0, 1)
+    %tile_0_2 = aie.tile(0, 2)
+  }
+}

--- a/test/npu-xrt/ctrl_packet_reconfig_elf/aie2.mlir
+++ b/test/npu-xrt/ctrl_packet_reconfig_elf/aie2.mlir
@@ -67,12 +67,13 @@ module {
 
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
-    aiex.runtime_sequence @run(%arg: memref<?xi8>, %arg0: memref<64x64xi8>, %arg1: memref<64x64xi8>) {
+    aiex.runtime_sequence @run(%arg0: memref<64x64xi8>, %arg1: memref<64x64xi8>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c56_i64 = arith.constant 56 : i64
       %c61_i64 = arith.constant 61 : i64
       %c64_i64 = arith.constant 64 : i64
+      aiex.npu.configure
       aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<64x64xi8>
       aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }

--- a/test/npu-xrt/ctrl_packet_reconfig_elf/aie2.mlir
+++ b/test/npu-xrt/ctrl_packet_reconfig_elf/aie2.mlir
@@ -67,14 +67,14 @@ module {
 
     aie.shim_dma_allocation @objFifo_in0(MM2S, 0, 0)
 
-    aiex.runtime_sequence @run(%arg0: memref<?xi8>, %arg1: memref<64x64xi8>, %arg2: memref<64x64xi8>) {
+    aiex.runtime_sequence @run(%arg: memref<?xi8>, %arg0: memref<64x64xi8>, %arg1: memref<64x64xi8>) {
       %c0_i64 = arith.constant 0 : i64
       %c1_i64 = arith.constant 1 : i64
       %c56_i64 = arith.constant 56 : i64
       %c61_i64 = arith.constant 61 : i64
       %c64_i64 = arith.constant 64 : i64
-      aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<64x64xi8>
-      aiex.npu.dma_memcpy_nd (%arg2[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64], packet = <pkt_id = 3, pkt_type = 0>) {id = 0 : i64, metadata = @objFifo_in0} : memref<64x64xi8>
+      aiex.npu.dma_memcpy_nd (%arg1[%c0_i64, %c0_i64, %c0_i64, %c0_i64][%c1_i64, %c1_i64, %c64_i64, %c64_i64][%c0_i64, %c0_i64, %c64_i64, %c1_i64]) {id = 1 : i64, metadata = @objFifo_out0, issue_token = true} : memref<64x64xi8>
       aiex.npu.dma_wait { symbol = @objFifo_out0 }
     }
 

--- a/test/npu-xrt/ctrl_packet_reconfig_elf/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_elf/run.lit
@@ -7,7 +7,7 @@
 // RUN: %python aiecc.py --aie-generate-xclbin --xclbin-name=aie1.xclbin aie1_overlay.mlir
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
-// RUN: %python aiecc.py --aie-generate-ctrlpkt --aie-generate-elf --elf-name=aie2_run_seq.elf aie2_overlay.mlir
+// RUN: %python aiecc.py --aie-generate-ctrlpkt --aie-generate-elf --elf-name=aie2.elf aie2_overlay.mlir
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_elf/run.lit
+++ b/test/npu-xrt/ctrl_packet_reconfig_elf/run.lit
@@ -7,7 +7,7 @@
 // RUN: %python aiecc.py --aie-generate-xclbin --xclbin-name=aie1.xclbin aie1_overlay.mlir
 //
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %S/aie2.mlir -o aie2_overlay.mlir
-// RUN: %python aiecc.py --aie-generate-ctrlpkt --aie-generate-npu-insts --npu-insts-name=aie2_run_seq.bin aie2_overlay.mlir
+// RUN: %python aiecc.py --aie-generate-ctrlpkt --aie-generate-elf --elf-name=aie2_run_seq.elf aie2_overlay.mlir
 //
 // RUN: clang %S/test.cpp -o test.exe -std=c++17 -Wall %xrt_flags -lrt -lstdc++ %test_utils_flags
 // RUN: %run_on_npu1% ./test.exe

--- a/test/npu-xrt/ctrl_packet_reconfig_elf/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig_elf/test.cpp
@@ -52,18 +52,14 @@ int main(int argc, const char *argv[]) {
 
   device.register_xclbin(xclbin);
 
-  xrt::elf elf0("ctrlpkt_dma_seq.elf");
+  xrt::elf elf0("aie2.elf");
   xrt::module mod0{elf0};
-
-  xrt::elf elf1("aie2_run_seq.elf");
-  xrt::module mod1{elf1};
 
   // get a hardware context
   xrt::hw_context context(device, xclbin.get_uuid());
 
   // get a kernel handle
   auto kernel0 = xrt::ext::kernel(context, mod0, kernelName);
-  auto kernel1 = xrt::ext::kernel(context, mod1, kernelName);
 
   xrt::bo bo_in = xrt::ext::bo(device, DATA_SIZE * sizeof(DATATYPE));
   xrt::bo bo_out = xrt::ext::bo(device, DATA_SIZE * sizeof(DATATYPE));
@@ -79,8 +75,7 @@ int main(int argc, const char *argv[]) {
 
   unsigned int opcode = 3;
 
-  kernel0(opcode).wait2();
-  kernel1(opcode, 0, 0, 0, bo_in, bo_out).wait2();
+  kernel0(opcode, 0, 0, 0, bo_in, bo_out).wait2();
 
   bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
 

--- a/test/npu-xrt/ctrl_packet_reconfig_elf/test.cpp
+++ b/test/npu-xrt/ctrl_packet_reconfig_elf/test.cpp
@@ -1,0 +1,111 @@
+//===- test.cpp -------------------------------------------000---*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Copyright (C) 2024, Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "xrt/xrt_bo.h"
+#include "xrt/xrt_device.h"
+#include "xrt/xrt_kernel.h"
+
+#include "xrt/experimental/xrt_elf.h"
+#include "xrt/experimental/xrt_ext.h"
+#include "xrt/experimental/xrt_kernel.h"
+#include "xrt/experimental/xrt_module.h"
+
+#include "test_utils.h"
+
+constexpr int DATA_SIZE = 64 * 64;
+#define DATATYPE int8_t
+
+int main(int argc, const char *argv[]) {
+
+  // Start the XRT test code
+  // Get a device handle
+  unsigned int device_index = 0;
+  auto device = xrt::device(device_index);
+
+  // Load the xclbin
+  // Skeleton xclbin containing only the control packet network
+  auto xclbin = xrt::xclbin(std::string("aie1.xclbin"));
+
+  
+  // Get the kernel from the xclbin
+  auto xkernels = xclbin.get_kernels();
+  auto xkernel = *std::find_if(xkernels.begin(), xkernels.end(),
+                               [](xrt::xclbin::kernel &k) {
+                                 auto name = k.get_name();
+                                 return name.rfind("MLIR_AIE", 0) == 0;
+                               });
+  auto kernelName = xkernel.get_name();
+
+  device.register_xclbin(xclbin);
+
+  xrt::elf elf0("ctrlpkt_dma_seq.elf");
+  xrt::module mod0{elf0};
+
+  xrt::elf elf1("aie2_run_seq.elf");
+  xrt::module mod1{elf1};
+
+  // get a hardware context
+  xrt::hw_context context(device, xclbin.get_uuid());
+
+  // get a kernel handle
+  auto kernel0 = xrt::ext::kernel(context, mod0, kernelName);
+  auto kernel1 = xrt::ext::kernel(context, mod1, kernelName);
+
+  xrt::bo bo_in = xrt::ext::bo(device, DATA_SIZE * sizeof(DATATYPE));
+  xrt::bo bo_out = xrt::ext::bo(device, DATA_SIZE * sizeof(DATATYPE));
+
+  std::vector<DATATYPE> srcVecA;
+  for (int i = 0; i < DATA_SIZE; i++)
+    srcVecA.push_back((i % 64) + 1);
+  memcpy(bo_in.map<DATATYPE *>(), srcVecA.data(),
+         (srcVecA.size() * sizeof(DATATYPE)));
+
+  // Synchronizing BOs
+  bo_in.sync(XCL_BO_SYNC_BO_TO_DEVICE);
+
+  unsigned int opcode = 3;
+
+  kernel0(opcode).wait2();
+  kernel1(opcode, 0, 0, 0, bo_in, bo_out).wait2();
+
+  bo_out.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
+
+  DATATYPE *bufOut = bo_out.map<DATATYPE *>();
+
+  int errors = 0;
+
+  for (uint32_t i = 0; i < DATA_SIZE; i++) {
+    uint32_t ref = srcVecA[i] + 12;
+    if (bufOut[i] != ref) {
+      std::cout << "Error in output " << std::to_string(bufOut[i])
+                << " != " << ref << std::endl;
+      errors++;
+    }
+    // else
+    //   std::cout << "Correct output " << std::to_string(bufOut[i])
+    //             << " == " << ref << std::endl;
+    // }
+  }
+
+  if (!errors) {
+    std::cout << "\nPASS!\n\n";
+    return 0;
+  }
+
+  std::cout << "\nfailed.\n\n";
+  return 1;
+}

--- a/utils/mlir_wheels/pyproject.toml
+++ b/utils/mlir_wheels/pyproject.toml
@@ -15,7 +15,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 build-verbosity = 3
-build = "cp310-*"
+build = "cp312-*"
 skip = ["*-manylinux_i686", "*-musllinux*"]
 manylinux-aarch64-image = "manylinux_2_28"
 manylinux-x86_64-image = "manylinux_2_28"


### PR DESCRIPTION
* Add `aiex.npu.configure` op.
* Modify control packet lowering (`aie-opt --convert-aie-to-control-packets`) to insert configuration control packet ops using `aiex.npu.configure` as insertion point.
* Modify control packet control sequence generation (`aie-opt --aie-ctrl-packet-to-dma`) to be "in-place", instead of creating new control sequence.

The effect of the above is to combine the control packet configuration and user control runtime sequences into one transaction binary. When used with `aiecc --aie-generate-ctrlpkt --aie-generate-elf`, the output elf will contain the combined transaction binary as well as the control packet payload.

Test `ctrl_packet_reconfig_elf` is updated to use the combined elf for configuration and control. The xclbin contains only the routing necessary to enable configuration with packets.

```c++
  // Skeleton xclbin containing only the control packet network
  auto xclbin = xrt::xclbin(std::string("aie1.xclbin"));
  ...
  // elf containing the design's configuration (as packet data) and control (as txn binary)
  xrt::elf elf0("aie2.elf");
  xrt::module mod0{elf0};
  ...
  unsigned int opcode = 3;
  auto kernel0 = xrt::ext::kernel(context, mod0, kernelName);
  ...
  // Arguments 1, 2, and 3 (all zero) are for the xrt managed runtime sequence and control packet payload.
  // These are loaded from the elf, managed by xrt, and do not appear in the host code.
  kernel0(opcode, 0, 0, 0, bo_in, bo_out).wait2();
```