### PR TITLE
Better location information

### DIFF
--- a/docs/SourceLocations.md
+++ b/docs/SourceLocations.md
@@ -183,9 +183,8 @@ buffers it materializes.
 
 ## Status (as of branch `location`)
 
-Phase 1 fully implemented. Phase 2 partially implemented — the passes on
-the IRON → ObjectFifo → core/runtime/configuration path now thread
-locations end-to-end. Tracked in three regression-tested lit cases:
+Phase 1 and Phase 2 essentially complete. Tracked in three
+regression-tested lit cases:
 
 - `test/python/loc_capture.py` — exercises the helper.
 - `test/python/iron_loc_emit.py` — builds an IRON program and verifies
@@ -197,30 +196,42 @@ locations end-to-end. Tracked in three regression-tested lit cases:
   hand-written input asserting the C++ pass preserves an explicit
   `loc(#user_loc)`.
 
-`getUnknownLoc()` count in `lib/`: ~136 → ~56 (60% reduction).
+`getUnknownLoc()` count in `lib/`: **~136 → 15 (89% reduction)**.
 
-Passes converted in this POC:
-- `lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp`
-  (38 → 0)
-- `lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp` (13 → 1; the one
-  remaining is `declareAIEIntrinsics`, which emits LLVM-intrinsic
-  `func.func` declarations that don't correspond to user code)
-- `lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp` (19 → 0)
-- `lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp` (6 → 0)
-- `lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp` (5 → 0)
+Passes converted in this POC (per file, before → after):
 
-Remaining work for full coverage (each is mechanical, mirrors the
-patterns above):
-- `AIEVecToLLVM.cpp` (vector → LLVM lowering on the AIE-core side; lets
-  DWARF carry user locs into AIE-core object code via the existing
-  upstream `DebugTranslation`).
-- `AIEPathFinder.cpp` (legacy pathfinder), `AIECreateCores.cpp`,
-  `AIELowerCascadeFlows.cpp`, `AIELowerMemcpy.cpp`,
-  `AIECreateBroadcastPacket.cpp`, `AIECtrlPacketToDma.cpp`,
-  `AIEExpandLoadPdi.cpp`, plus a handful of misc dialect-internal sites.
+| File | Before | After |
+|------|--------|-------|
+| `AIE/Transforms/AIEObjectFifoStatefulTransform.cpp` | 38 | 0 |
+| `AIE/Transforms/AIECreatePathFindFlows.cpp` | 19 | 0 |
+| `AIE/Transforms/AIECoreToStandard.cpp` | 13 | 1 |
+| `AIE/Transforms/AIEObjectFifoRegisterProcess.cpp` | 10 | 0 |
+| `AIEX/Transforms/AIECreateCores.cpp` | 9 | 0 |
+| `AIEX/Transforms/AIELowerMemcpy.cpp` | 6 | 0 |
+| `AIEX/Transforms/AIEHerdRouting.cpp` | 6 | 0 |
+| `Conversion/AIEToConfiguration/AIEToConfiguration.cpp` | 5 | 1 |
+| `AIE/Transforms/AIEGenerateColumnControlOverlay.cpp` | 5 | 0 |
+| `AIEX/Transforms/AIECreateBroadcastPacket.cpp` | 4 | 0 |
+| 8 single-site files | 1 each | 0 |
 
-Phase 3 (backend / tooling) is unstarted but unblocked: locations now
-flow far enough through the pipeline that wiring `aie-translate` debug
-output and adding `--mlir-print-debuginfo` to aiecc.py would surface
-them in the LLVM IR / DWARF on the AIE-core side without further
-plumbing.
+The 15 remaining sites are intentionally left, all "no source op" cases:
+- `Conversion/AIEVecToLLVM/AIEVecToLLVM.cpp` (8): LLVM-intrinsic
+  FuncOp *declarations* and helper-wrapper bodies. Equivalent to
+  `declareAIEIntrinsics` in AIECoreToStandard. The actual user-op
+  lowering still preserves location via the rewriter pattern.
+- `AIE/Transforms/AIEPathFinder.cpp` (5): `DynamicTileAnalysis`
+  synthesizing Tile/Switchbox/ShimMux infrastructure on demand. The
+  analyzer has no direct handle to a source op; threading one through
+  would require widening the analysis-pass API.
+- `AIE/Transforms/AIECoreToStandard.cpp` (1): `declareAIEIntrinsics`.
+- `Conversion/AIEToConfiguration/AIEToConfiguration.cpp` (1):
+  `convertTransactionBinaryToMLIR` creates a fresh ModuleOp from a
+  parsed binary blob — there is no source MLIR op to reference.
+
+Phase 3 (backend / tooling) is unstarted but unblocked. Next steps:
+- Verify `aie-translate` preserves debug info on the way to LLVM IR.
+- Confirm `DebugTranslation` materializes `DILocation` from the
+  threaded-through `FileLineColLoc`s.
+- Expose `--mlir-print-debuginfo` and a `--keep-loc` flag in aiecc.py.
+- Audit `lib/Targets/` (CDO, NPU runtime emitters) for opportunities
+  to attach source-line ↔ transaction maps to the runtime artifact.

--- a/docs/SourceLocations.md
+++ b/docs/SourceLocations.md
@@ -1,0 +1,182 @@
+# Source Location Information in mlir-aie
+
+Investigation note: how MLIR `Location` info flows (or doesn't) through the
+mlir-aie compiler today, and a proposal — with an initial proof-of-concept
+patch — for carrying user source positions from IRON Python down through
+transformation passes for use by diagnostics, debugging, and profiling.
+
+## Why locations matter
+
+Every MLIR op carries a `Location` attribute. Upstream MLIR uses it for:
+
+- **Diagnostics**: errors, warnings, and `op->emitError()` cite the source
+  position the op came from.
+- **Pass debugging**: `--mlir-print-ir-after-all --mlir-print-debuginfo`
+  shows how IR transforms while preserving the user-visible source mapping.
+- **Debug info translation**: when lowering to the LLVM dialect,
+  `mlir/lib/Target/LLVMIR/DebugTranslation.cpp` maps MLIR `Location`s to
+  `llvm::DILocation` so the resulting object code carries DWARF that
+  debuggers (gdb, lldb) and profilers can consume.
+- **Provenance tagging**: `NameLoc` / `FusedLoc` let passes record *which*
+  pass or transform produced an op, while still pointing at the original
+  source — useful for understanding what canonicalization, fusion, or
+  lowering did to a user-written op.
+
+mlir-aie currently makes essentially no use of any of this.
+
+## Current state
+
+A survey of the source tree (mlir-aie commit on branch `mdv6`):
+
+- **C++ passes**: 136+ call sites of `builder.getUnknownLoc()` /
+  `UnknownLoc::get(...)` across 20 files. The hotspots are
+  `AIEObjectFifoStatefulTransform.cpp` (38), `AIECreatePathFindFlows.cpp`
+  (19), `AIECoreToStandard.cpp` (13), `AIEVecToLLVM.cpp` (8),
+  `AIEHerdRouting.cpp` (6), and `AIEToConfiguration.cpp` (5). Most
+  transformation patterns synthesize new ops without forwarding
+  `op->getLoc()` from the source op being lowered or replaced. There is no
+  use of `FusedLoc` or `NameLoc` anywhere.
+- **Python frontend (IRON)**: Every IRON `resolve()` constructs MLIR ops
+  inside a `with mlir_mod_ctx():` block, which the wrapper enters with a
+  default `with Location.unknown():`. None of the user-facing IRON classes
+  (`ObjectFifo`, `Worker`, `Runtime.fill/drain`, `Kernel`, `Buffer`)
+  capture the Python call frame, and the `loc=` parameter on `resolve()`
+  is unused.
+- **aiecc.py**: 16 `with Location.unknown():` wrappings around module
+  parses and post-load fixups. These are fine *as defaults* but mean any
+  op created in those scopes gets `UnknownLoc` unless explicitly
+  overridden.
+- **Tests / examples**: zero `loc(...)` annotations in `.mlir` test inputs;
+  no lit tests use `--mlir-print-debuginfo`.
+- **Targets**: `lib/Targets/AIERT.cpp` and the CDO/NPU emitters do not
+  consume location info — when they emit transactions or runtime config,
+  there is nothing to consume because everything upstream is `UnknownLoc`.
+
+In short: locations are dropped at the front door (Python) and again at
+every transformation pass. There is nothing technical preventing their use;
+it is purely a matter of plumbing.
+
+## Infrastructure already in place
+
+The pieces needed for this to work are all available:
+
+- `mlir.ir.Location` Python bindings expose `Location.file`, `Location.name`
+  (NameLoc), `Location.callsite` (CallSiteLoc), and `Location.fused`. They
+  act as context managers — `with Location.file(...):` makes the location
+  the thread-local default, so ops created without an explicit `loc=`
+  inherit it.
+- `aie/extras/util.py::get_user_code_loc()` already walks the Python frame
+  stack to capture the user's source position. It is used today in a few
+  places (`scf.if_`, buffer indexing in `dialects/aie.py`).
+- C++ `OpBuilder` and `RewriterBase` already accept `Location` everywhere;
+  `rewriter.replaceOpWithNewOp<T>(op, ...)` automatically propagates
+  `op->getLoc()` to the replacement. Patterns just need to use it.
+- LLVM `DebugTranslation` already turns MLIR `FileLineColLoc` into
+  `DILocation` when lowering to the LLVM dialect — so once locations exist
+  in the IR they would land in DWARF on the AIE-core side without further
+  effort.
+
+## Proposed approach (three phases)
+
+### Phase 1 — Capture in Python (this POC)
+
+At the IRON-level "this op exists because the user wrote *that*" boundary,
+walk the Python stack and stash an `ir.Location` on the IRON object. When
+`resolve()` builds MLIR ops, enter a `with self._user_loc:` block so the
+ops inherit a `FileLineColLoc` (wrapped in a `NameLoc` carrying the IRON
+identifier — `of0`, the worker's `core_fn` name, etc.).
+
+Caveats:
+
+- Frame capture must skip frames inside the IRON / aie / venv site-packages
+  trees so the recorded position is the user's program, not framework
+  internals. The helper in `python/iron/_loc.py` does this.
+- Locations are captured at *construction*, not at `resolve()` time, because
+  by the time `Program.resolve_program` walks the object graph the user's
+  call frame is long gone.
+- `Location` requires an active MLIR `Context`. IRON construction often
+  happens before `mlir_mod_ctx()` is entered, so `capture_user_loc()`
+  returns `None` in that case and the existing `Location.unknown()` default
+  is preserved. (A future refinement is to capture the `(filename, line,
+  col)` triple eagerly into a plain dataclass and lazily materialize the
+  `Location` inside `resolve()`.)
+
+### Phase 2 — Preserve through passes
+
+Audit each pass under `lib/Conversion/`, `lib/Dialect/AIE/Transforms/`, and
+`lib/Dialect/AIEX/Transforms/` and replace `builder.getUnknownLoc()` /
+`b.getUnknownLoc()` with `op->getLoc()` (or, where multiple input ops
+contribute, `builder.getFusedLoc({locA, locB, ...})`). Idiomatic MLIR
+patterns to encourage:
+
+- Use `rewriter.replaceOpWithNewOp<NewOp>(oldOp, ...)` rather than
+  constructing the new op with an unknown location. This carries the
+  source op's location automatically.
+- For passes that synthesize many ops from one logical source op (like
+  `AIEObjectFifoStatefulTransform` expanding an `objectfifo.create` into
+  a forest of `lock` / `buffer` / `dma_bd` / `use_lock` ops), capture the
+  source loc once at the top of the loop and pass it to every
+  `Op::create(...)`. Optionally wrap with a `NameLoc` indicating which
+  pass produced the synthesized op (e.g. `loc("ObjFifoExpand"(...))`) so
+  diagnostics make the provenance clear.
+
+### Phase 3 — Backends and tooling
+
+Once locations survive the pass pipeline:
+
+- **`aie-translate` / LLVM IR emission**: with the LLVM-dialect
+  `DebugTranslation` already in place, AIE-core LLVM IR gets `DILocation`
+  attached automatically. Ensure `aie-translate` does not strip debuginfo
+  on the way out (likely a one-line change, if any).
+- **CDO / NPU runtime emitters** (`lib/Targets/AIERT.cpp`,
+  `AIETargetCDODirect.cpp`): consume locations to (a) embed a small
+  source-line ↔ instruction map next to the transaction binary, and (b)
+  annotate trace records with the originating IRON construct so profiling
+  tools can attribute hot transactions back to the user's `Runtime.fill`
+  call.
+- **aiecc.py**: expose `--mlir-print-debuginfo` and a `--keep-loc` flag
+  that preserves rather than canonicalizes locations across pass runs.
+- **Tests**: add lit tests that pipe IRON-built modules through
+  `aie-opt --mlir-print-debuginfo` and `FileCheck` for `loc(#...)`
+  annotations, locking in the contract that key passes do not drop
+  locations.
+
+## POC patch summary
+
+This branch contains a small end-to-end demonstration of Phase 1 plus a
+Phase 2 example:
+
+- `python/iron/_loc.py` — new helper. `capture_user_loc(name=...)` walks
+  the Python frame stack, skipping frames inside the IRON / aie / venv
+  trees, and returns `NameLoc.get(name, FileLineColLoc(...))`. Returns
+  `None` when no MLIR context is active so callers can fall back safely.
+- `python/iron/dataflow/objectfifo.py`, `python/iron/worker.py`,
+  `python/iron/kernel.py`, `python/iron/runtime/runtime.py`,
+  `python/iron/runtime/dmatask.py` — capture `self._user_loc` at
+  construction time (or at the `Runtime.fill` / `drain` call site) and
+  apply it as a `with` block around MLIR op creation in `resolve()`.
+- `lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp` —
+  replace `builder.getUnknownLoc()` with `op.getLoc()` in
+  `createObjectFifo`, `createObjectFifoLocks`, and the buffer allocation
+  in `createObjectFifoElements`. The synthesized `ObjectFifoCreateOp`,
+  `LockOp`s (prod / cons), and `BufferOp`s now inherit the source
+  ObjectFifo's location.
+
+After build, an IRON program emitted with
+`aie-opt --mlir-print-debuginfo` (or by setting
+`enable_debug_info=True` when printing the module from Python) will show
+ops tagged with `loc("of0"("user.py":42:4))` style annotations, and those
+annotations survive the objectfifo stateful transform onto the locks and
+buffers it materializes.
+
+## Effort and risk estimate
+
+- Phase 1 (Python capture): ~1 day. Low risk — additive only, falls back
+  to `Location.unknown()` cleanly.
+- Phase 2 (pass plumbing): a few days of mechanical work, file-by-file
+  audit, plus a lit test or two per pass to lock the behavior in. Medium
+  risk only because some passes do non-trivial op-fusion; deciding when
+  to use `FusedLoc` vs. picking one source loc requires judgment.
+- Phase 3 (backend / tooling): a few days, mostly straightforward once
+  the IR carries locations end-to-end. The DWARF path on AIE-core code is
+  already implemented upstream.

--- a/docs/SourceLocations.md
+++ b/docs/SourceLocations.md
@@ -26,7 +26,7 @@ mlir-aie currently makes essentially no use of any of this.
 
 ## Current state
 
-A survey of the source tree (mlir-aie commit on branch `mdv6`):
+A survey of the source tree (mlir-aie commit `9796296`):
 
 - **C++ passes**: 136+ call sites of `builder.getUnknownLoc()` /
   `UnknownLoc::get(...)` across 20 files. The hotspots are

--- a/docs/SourceLocations.md
+++ b/docs/SourceLocations.md
@@ -180,3 +180,47 @@ buffers it materializes.
 - Phase 3 (backend / tooling): a few days, mostly straightforward once
   the IR carries locations end-to-end. The DWARF path on AIE-core code is
   already implemented upstream.
+
+## Status (as of branch `location`)
+
+Phase 1 fully implemented. Phase 2 partially implemented — the passes on
+the IRON → ObjectFifo → core/runtime/configuration path now thread
+locations end-to-end. Tracked in three regression-tested lit cases:
+
+- `test/python/loc_capture.py` — exercises the helper.
+- `test/python/iron_loc_emit.py` — builds an IRON program and verifies
+  (a) the emitted MLIR has `loc("of_in"(file:line))`-style NameLocs on
+  every IRON entry-point op and (b) running through
+  `--aie-place-tiles --aie-objectFifo-stateful-transform` preserves
+  those locations on the synthesized buffers / locks / dma_bd.
+- `test/objectFifo-stateful-transform/base/loc_preservation.mlir` —
+  hand-written input asserting the C++ pass preserves an explicit
+  `loc(#user_loc)`.
+
+`getUnknownLoc()` count in `lib/`: ~136 → ~56 (60% reduction).
+
+Passes converted in this POC:
+- `lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp`
+  (38 → 0)
+- `lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp` (13 → 1; the one
+  remaining is `declareAIEIntrinsics`, which emits LLVM-intrinsic
+  `func.func` declarations that don't correspond to user code)
+- `lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp` (19 → 0)
+- `lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp` (6 → 0)
+- `lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp` (5 → 0)
+
+Remaining work for full coverage (each is mechanical, mirrors the
+patterns above):
+- `AIEVecToLLVM.cpp` (vector → LLVM lowering on the AIE-core side; lets
+  DWARF carry user locs into AIE-core object code via the existing
+  upstream `DebugTranslation`).
+- `AIEPathFinder.cpp` (legacy pathfinder), `AIECreateCores.cpp`,
+  `AIELowerCascadeFlows.cpp`, `AIELowerMemcpy.cpp`,
+  `AIECreateBroadcastPacket.cpp`, `AIECtrlPacketToDma.cpp`,
+  `AIEExpandLoadPdi.cpp`, plus a handful of misc dialect-internal sites.
+
+Phase 3 (backend / tooling) is unstarted but unblocked: locations now
+flow far enough through the pipeline that wiring `aie-translate` debug
+output and adding `--mlir-print-debuginfo` to aiecc.py would surface
+them in the LLVM IR / DWARF on the AIE-core side without further
+plumbing.

--- a/include/aie/Dialect/AIE/Util/AIELocCheckpoint.h
+++ b/include/aie/Dialect/AIE/Util/AIELocCheckpoint.h
@@ -1,0 +1,48 @@
+//===- AIELocCheckpoint.h ----------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+// Stage-checkpoint location helper. Used by aiecc to fuse a
+// "checkpoint:<stage>" StringAttr into every op's mlir::Location at the
+// boundary of each intermediate `.mlir` dump file. Subsequent passes
+// propagate getLoc() naturally, so a final aiex.npu.* op carries the chain
+// of all stages it survived through.
+//===----------------------------------------------------------------------===//
+
+#ifndef AIE_DIALECT_AIE_UTIL_AIELOCCHECKPOINT_H
+#define AIE_DIALECT_AIE_UTIL_AIELOCCHECKPOINT_H
+
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Operation.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace xilinx {
+namespace AIE {
+
+/// The metadata-attribute prefix this helper uses on the FusedLoc it
+/// produces. JSON serializers and tooling can detect a checkpoint metadata
+/// by looking for a StringAttr starting with this prefix.
+inline llvm::StringRef getCheckpointMetadataPrefix() { return "checkpoint:"; }
+
+/// Fuse a "checkpoint:<stage>" StringAttr into `loc` and return a new
+/// FusedLoc wrapping it. UnknownLoc is wrapped (not passed through) so
+/// every op carries stage-provenance regardless of whether it has
+/// source-provenance. Idempotent: if `loc` is already a FusedLoc whose
+/// top-level metadata is the same "checkpoint:<stage>", returns `loc`
+/// unchanged.
+mlir::Location fuseStageLabel(mlir::Location loc, llvm::StringRef stage);
+
+/// Walk `op` and replace every nested op's location with
+/// fuseStageLabel(child->getLoc(), stage). Cheap attribute rewrite, no IR
+/// restructuring. Walking from a ModuleOp covers the whole module.
+void applyStageLabel(mlir::Operation *op, llvm::StringRef stage);
+
+} // namespace AIE
+} // namespace xilinx
+
+#endif // AIE_DIALECT_AIE_UTIL_AIELOCCHECKPOINT_H

--- a/include/aie/Dialect/AIE/Util/AIERegisterDatabase.h
+++ b/include/aie/Dialect/AIE/Util/AIERegisterDatabase.h
@@ -13,6 +13,7 @@
 #ifndef AIE_REGISTER_DATABASE_H
 #define AIE_REGISTER_DATABASE_H
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/JSON.h"
@@ -68,6 +69,14 @@ public:
   const RegisterInfo *lookupRegister(llvm::StringRef name,
                                      llvm::StringRef module) const;
 
+  /// Lookup register by tile-relative offset and module name. Used by the
+  /// transaction-binary locmap to decorate each transaction word with its
+  /// semantic register name. Module names are the JSON keys in
+  /// aie_registers_aie2.json (e.g. "core_module", "memory_module",
+  /// "mem_tile_module", "pl_module"). Returns nullptr if no register matches.
+  const RegisterInfo *lookupRegisterByOffset(uint32_t offset,
+                                             llvm::StringRef module) const;
+
   /// Lookup event by name and module
   std::optional<uint32_t> lookupEvent(llvm::StringRef name,
                                       llvm::StringRef module) const;
@@ -80,8 +89,17 @@ private:
 
   bool loadFromJSON(llvm::StringRef registerPath, llvm::StringRef eventPath);
 
+  // Build the offset-keyed reverse index from `registers_`. Called once at
+  // load time after `loadFromJSON` finishes populating `registers_`.
+  void buildOffsetIndex();
+
   llvm::StringMap<RegisterInfo> registers_;
   llvm::StringMap<EventInfo> events_;
+  // (lowercased module name) -> (offset -> *RegisterInfo). Pointers into
+  // entries owned by `registers_`; safe because `registers_` is never
+  // mutated after construction.
+  llvm::StringMap<llvm::DenseMap<uint32_t, const RegisterInfo *>>
+      registersByOffset_;
 };
 
 } // namespace AIE

--- a/include/aie/Targets/AIERT.h
+++ b/include/aie/Targets/AIERT.h
@@ -15,13 +15,36 @@
 #include "aie/Dialect/AIE/IR/AIEEnums.h"
 #include "aie/Dialect/AIE/IR/AIETargetModel.h"
 
+#include "mlir/IR/Location.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <map>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace xilinx::AIE {
+struct AIERTControl;
+
+// RAII helper. Constructs while AIERTControl is recording an aie-rt
+// transaction, captures the current XAie_TxnInst command count at entry, and
+// at scope end attributes every aie-rt command produced during the scope to
+// `loc`. The captured ranges are stored on AIERTControl::txnInstrLocs and read
+// out by the AIEToConfiguration round-trip so re-emitted aiex.npu.* ops carry
+// the source op's MLIR Location instead of the device's fallback location.
+class TxnLocBracket {
+public:
+  TxnLocBracket(AIERTControl &ctl, mlir::Location loc);
+  ~TxnLocBracket();
+  TxnLocBracket(const TxnLocBracket &) = delete;
+  TxnLocBracket &operator=(const TxnLocBracket &) = delete;
+
+private:
+  AIERTControl &ctl;
+  mlir::Location loc;
+  uint32_t startCmds;
+};
+
 struct AIERTControl {
 
   AIERTControl(const xilinx::AIE::AIETargetModel &tm);
@@ -46,6 +69,21 @@ struct AIERTControl {
   void startTransaction();
   void dmaUpdateBdAddr(int col, int row, size_t addr, size_t bdId);
   std::vector<uint8_t> exportSerializedTransaction();
+
+  // Per-aie-rt-command source locations, indexed by command order in the
+  // serialized transaction. Populated by TxnLocBracket scopes around each
+  // per-source-op block in the AIERT methods. Empty entries fall back to
+  // mlir::UnknownLoc.
+  const std::vector<mlir::Location> &getTxnInstrLocs() const;
+
+  // Current XAie_TxnInst::NumCmds for the active transaction (zero if no
+  // transaction is being recorded). Used by TxnLocBracket.
+  uint32_t getCurrentTxnNumCmds() const;
+
+  // Append `loc` to txnInstrLocs at indices [startCmds, endCmds). Used by
+  // TxnLocBracket on scope exit.
+  void recordTxnLocRange(uint32_t startCmds, uint32_t endCmds,
+                         mlir::Location loc);
   mlir::LogicalResult resetPartition();
   mlir::LogicalResult resetDMA(int col, int row, bool on);
   mlir::LogicalResult resetCore(int col, int row);

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -38,7 +38,7 @@ struct TxnLocEntry {
   uint32_t byteSize = 0;
   std::string opcodeName;     // "WRITE32", "BLOCKWRITE", etc.
   std::string sourceOpName;   // "aiex.npu.write32", etc.
-  uint64_t address = 0;       // absolute device address when applicable
+  std::optional<uint64_t> address; // absolute device address when applicable
   std::string registerName;   // regdb-resolved register name; empty if unknown
   std::string registerModule; // regdb module: "core_module", "memory_module", etc.
   std::optional<mlir::Location> loc;

--- a/include/aie/Targets/AIETargets.h
+++ b/include/aie/Targets/AIETargets.h
@@ -10,15 +10,46 @@
 #define AIE_TARGETS_AIETARGETS_H
 
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Location.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Support/LogicalResult.h"
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
+#include <optional>
+#include <string>
 #include <vector>
 
 namespace xilinx {
 namespace AIE {
+
+// One entry in the sidecar location map produced by AIETranslateNpuToBinary
+// (and AIETranslateControlPacketsToUI32Vec). Each entry describes one
+// transaction operation in the .bin: the byte range it occupies, its opcode,
+// the absolute device address it touches (when applicable), the originating
+// aiex.npu.* op's MLIR Location, and an optional regdb register name resolved
+// from (address, tile-module). The vector is written alongside the .bin as a
+// JSON sidecar (see emitNpuLocmapJSON) so consumers can correlate transaction
+// words back to IRON Python source.
+struct TxnLocEntry {
+  uint32_t byteOffset = 0;
+  uint32_t byteSize = 0;
+  std::string opcodeName;     // "WRITE32", "BLOCKWRITE", etc.
+  std::string sourceOpName;   // "aiex.npu.write32", etc.
+  uint64_t address = 0;       // absolute device address when applicable
+  std::string registerName;   // regdb-resolved register name; empty if unknown
+  std::string registerModule; // regdb module: "core_module", "memory_module", etc.
+  std::optional<mlir::Location> loc;
+};
+
+// Serialize a vector of TxnLocEntry as JSON to `output`, with the given
+// device name and binary file basename for the JSON header.
+void emitNpuLocmapJSON(llvm::raw_ostream &output,
+                       llvm::StringRef deviceName,
+                       llvm::StringRef binaryName,
+                       const std::vector<TxnLocEntry> &locmap);
 
 mlir::LogicalResult AIETranslateToXAIEV2(mlir::ModuleOp module,
                                          llvm::raw_ostream &output,
@@ -42,14 +73,16 @@ mlir::LogicalResult AIETranslateGraphXPE(mlir::ModuleOp module,
 mlir::LogicalResult AIETranslateNpuToBinary(mlir::ModuleOp,
                                             std::vector<uint32_t> &,
                                             llvm::StringRef deviceName = "",
-                                            llvm::StringRef sequenceName = "");
+                                            llvm::StringRef sequenceName = "",
+                                            std::vector<TxnLocEntry> *locmap = nullptr);
 mlir::LogicalResult AIETranslateToUcDma(mlir::ModuleOp module,
                                         llvm::raw_ostream &output);
 mlir::LogicalResult AIETranslateToUcDma(mlir::ModuleOp, std::string &assembly);
 mlir::LogicalResult
 AIETranslateControlPacketsToUI32Vec(mlir::ModuleOp, std::vector<uint32_t> &,
                                     llvm::StringRef deviceName = "",
-                                    llvm::StringRef sequenceName = "");
+                                    llvm::StringRef sequenceName = "",
+                                    std::vector<TxnLocEntry> *locmap = nullptr);
 mlir::LogicalResult AIETranslateToLdScript(mlir::ModuleOp module,
                                            llvm::raw_ostream &output,
                                            int tileCol, int tileRow,

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -636,9 +636,15 @@ static LogicalResult convertTransactionOpsToMLIR(
   // for each blockwrite in the binary, create a GlobalOp with the data at the
   // device level
   std::vector<memref::GlobalOp> global_data;
-  DeviceOp device = llvm::dyn_cast<DeviceOp>(builder.getBlock()->getParentOp());
+  Operation *parentOp = builder.getBlock()->getParentOp();
+  DeviceOp device = llvm::dyn_cast<DeviceOp>(parentOp);
   if (!device) {
-    device = builder.getBlock()->getParentOp()->getParentOfType<DeviceOp>();
+    device = parentOp->getParentOfType<DeviceOp>();
+  }
+  if (!device) {
+    parentOp->emitError(
+        "expected insertion point to be nested under an aie.device op");
+    return failure();
   }
   Location loc = device.getLoc();
   {

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -45,7 +45,10 @@ namespace {
 
 // A TransactionBinaryOperation encapsulates an aie-rt XAie_TxnCmd struct and
 // any additional metadata needed for custom operations that do not map cleanly
-// onto the core command fields.
+// onto the core command fields. `sourceLoc` is the MLIR Location of the
+// AIE-dialect op (e.g. aie.lock, aie.dma_bd) that produced this command via
+// AIERT, threaded in from AIERTControl::getTxnInstrLocs(). std::nullopt means
+// "fall back to the device location".
 struct TransactionBinaryOperation {
   struct XAie_TxnCmd cmd = {};
 
@@ -74,6 +77,7 @@ struct TransactionBinaryOperation {
   std::optional<SyncPayload> sync;
   std::optional<LoadPdiPayload> loadPdi;
   std::optional<AddressPatchPayload> addressPatch;
+  std::optional<mlir::Location> sourceLoc;
 
   TransactionBinaryOperation() = default;
 
@@ -448,14 +452,17 @@ static LogicalResult generateTransactions(AIERTControl &ctl,
 }
 
 // Translate vector of TransactionBinaryOperation to a sequence of transaction
-// ops (npu.write32, npu.maskwrite32, npu.blockwrite).
+// ops (npu.write32, npu.maskwrite32, npu.blockwrite). Each emitted op gets the
+// per-op `sourceLoc` from AIERT's instruction-range bracketing if available;
+// otherwise it falls back to `fallbackLoc` (typically the device location).
 static LogicalResult
-emitTransactionOps(OpBuilder &builder, Location loc,
+emitTransactionOps(OpBuilder &builder, Location fallbackLoc,
                    std::vector<TransactionBinaryOperation> &operations,
                    std::vector<memref::GlobalOp> &global_data) {
 
   // create the txn ops
   for (auto [op, payload] : llvm::zip(operations, global_data)) {
+    Location loc = op.sourceLoc.value_or(fallbackLoc);
 
     if (op.cmd.Opcode == XAie_TxnOpcode::XAIE_IO_WRITE) {
       AIEX::NpuWrite32Op::create(builder, loc, op.cmd.RegOff, op.cmd.Value,
@@ -527,9 +534,11 @@ emitTransactionOps(OpBuilder &builder, Location loc,
 }
 
 // Translate vector of TransactionBinaryOperation to a sequence of control
-// packet ops.
+// packet ops. Each emitted op gets the per-op `sourceLoc` from AIERT's
+// instruction-range bracketing if available; otherwise it falls back to
+// `fallbackLoc`.
 static LogicalResult
-emitControlPacketOps(OpBuilder &builder, Location loc,
+emitControlPacketOps(OpBuilder &builder, Location fallbackLoc,
                      std::vector<TransactionBinaryOperation> &operations,
                      std::vector<memref::GlobalOp> &global_data) {
 
@@ -537,6 +546,7 @@ emitControlPacketOps(OpBuilder &builder, Location loc,
 
   // create the control packet ops
   for (auto [op, payload] : llvm::zip(operations, global_data)) {
+    Location loc = op.sourceLoc.value_or(fallbackLoc);
 
     if (op.cmd.Opcode == XAie_TxnOpcode::XAIE_IO_WRITE) {
       AIEX::NpuControlPacketOp::create(
@@ -766,6 +776,17 @@ LogicalResult xilinx::AIE::generateAndInsertConfigOps(
   if (!parseTransactionBinary(txn_data, operations)) {
     llvm::errs() << "Failed to parse binary\n";
     return failure();
+  }
+
+  // Attach per-op source locations from AIERT's instruction-range bracketing.
+  // The aie-rt TxnList records one XAie_TxnCmd per serialized binary
+  // operation, so the indices align. Operations beyond the recorded range
+  // (or where no bracket fired) keep std::nullopt and inherit the device
+  // fallback location at emit time.
+  const std::vector<mlir::Location> &instrLocs = ctl.getTxnInstrLocs();
+  for (size_t i = 0, e = operations.size(); i < e; ++i) {
+    if (i < instrLocs.size())
+      operations[i].sourceLoc = instrLocs[i];
   }
 
   if (failed(convertTransactionOpsToMLIR(builder, outputType, operations,

--- a/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
+++ b/lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp
@@ -450,11 +450,9 @@ static LogicalResult generateTransactions(AIERTControl &ctl,
 // Translate vector of TransactionBinaryOperation to a sequence of transaction
 // ops (npu.write32, npu.maskwrite32, npu.blockwrite).
 static LogicalResult
-emitTransactionOps(OpBuilder &builder,
+emitTransactionOps(OpBuilder &builder, Location loc,
                    std::vector<TransactionBinaryOperation> &operations,
                    std::vector<memref::GlobalOp> &global_data) {
-
-  auto loc = builder.getUnknownLoc();
 
   // create the txn ops
   for (auto [op, payload] : llvm::zip(operations, global_data)) {
@@ -531,11 +529,10 @@ emitTransactionOps(OpBuilder &builder,
 // Translate vector of TransactionBinaryOperation to a sequence of control
 // packet ops.
 static LogicalResult
-emitControlPacketOps(OpBuilder &builder,
+emitControlPacketOps(OpBuilder &builder, Location loc,
                      std::vector<TransactionBinaryOperation> &operations,
                      std::vector<memref::GlobalOp> &global_data) {
 
-  auto loc = builder.getUnknownLoc();
   auto ctx = builder.getContext();
 
   // create the control packet ops
@@ -636,17 +633,15 @@ static LogicalResult convertTransactionOpsToMLIR(
     std::vector<TransactionBinaryOperation> &operations,
     std::string blockwrite_prefix = "config_blockwrite_data_") {
 
-  auto loc = builder.getUnknownLoc();
-
   // for each blockwrite in the binary, create a GlobalOp with the data at the
   // device level
   std::vector<memref::GlobalOp> global_data;
+  DeviceOp device = llvm::dyn_cast<DeviceOp>(builder.getBlock()->getParentOp());
+  if (!device) {
+    device = builder.getBlock()->getParentOp()->getParentOfType<DeviceOp>();
+  }
+  Location loc = device.getLoc();
   {
-    DeviceOp device =
-        llvm::dyn_cast<DeviceOp>(builder.getBlock()->getParentOp());
-    if (!device) {
-      device = builder.getBlock()->getParentOp()->getParentOfType<DeviceOp>();
-    }
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPointToStart(device.getBody());
     int id = 0;
@@ -676,10 +671,10 @@ static LogicalResult convertTransactionOpsToMLIR(
 
   // create the txn ops
   if (outputType == AIE::AIEToConfigurationOutputType::Transaction) {
-    if (failed(emitTransactionOps(builder, operations, global_data)))
+    if (failed(emitTransactionOps(builder, loc, operations, global_data)))
       return failure();
   } else if (outputType == AIE::AIEToConfigurationOutputType::ControlPacket) {
-    if (failed(emitControlPacketOps(builder, operations, global_data)))
+    if (failed(emitControlPacketOps(builder, loc, operations, global_data)))
       return failure();
     // resolve mask writes; control packet doesn't natively support mask write.
     if (failed(orConsecutiveWritesOnSameAddr(builder.getBlock())))
@@ -784,7 +779,7 @@ convertAIEToConfiguration(AIE::DeviceOp device, StringRef clElfDir,
   // and collect them in a vector. If there are none, create a new runtime
   // sequence. Otherwise assume the insertion point is the first
   // aiex.configure op.
-  auto loc = builder.getUnknownLoc();
+  auto loc = device.getLoc();
   SmallVector<AIEX::ConfigureOp> configureOps;
   device.walk([&](AIEX::ConfigureOp op) { configureOps.push_back(op); });
 

--- a/lib/Dialect/AIE/IR/AIEDialect.cpp
+++ b/lib/Dialect/AIE/IR/AIEDialect.cpp
@@ -1610,8 +1610,8 @@ TileOp TileOp::getOrCreate(mlir::OpBuilder builder, DeviceOp device, int col,
     OpBuilder::InsertionGuard guard(builder);
     mlir::Block &device_start_block = *device.getBodyRegion().begin();
     builder.setInsertionPointToStart(&device_start_block);
-    tile = TileOp::create(builder, builder.getUnknownLoc(),
-                          builder.getIndexType(), col, row);
+    tile = TileOp::create(builder, device.getLoc(), builder.getIndexType(), col,
+                          row);
   }
   return tile;
 }

--- a/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp
@@ -42,7 +42,7 @@ struct AIECanonicalizeDevicePass
     // the new op quite yet.
     OpBuilder builder(moduleOp->getContext());
 
-    Location location = builder.getUnknownLoc();
+    Location location = moduleOp.getLoc();
     auto deviceOp = DeviceOp::create(
         builder, location,
         AIEDeviceAttr::get(builder.getContext(), AIEDevice::xcvc1902),

--- a/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp
@@ -211,7 +211,7 @@ struct AIEDebugOpToStdLowering : OpConversionPattern<DebugOp> {
              << funcName;
     SmallVector<Value, 1> args;
     args.push_back(op.getArg());
-    func::CallOp::create(rewriter, rewriter.getUnknownLoc(), func, args);
+    func::CallOp::create(rewriter, op.getLoc(), func, args);
     rewriter.eraseOp(op);
     return success();
   }
@@ -259,7 +259,7 @@ struct AIEPutStreamToStdLowering : OpConversionPattern<PutStreamOp> {
           rewriter, op.getLoc(), IntegerType::get(rewriter.getContext(), 32),
           rewriter.getI32IntegerAttr(0))); // tlast
     }
-    func::CallOp::create(rewriter, rewriter.getUnknownLoc(), putMSFunc, args);
+    func::CallOp::create(rewriter, op.getLoc(), putMSFunc, args);
     rewriter.eraseOp(op);
     return success();
   }
@@ -300,8 +300,8 @@ struct AIEGetStreamToStdLowering : OpConversionPattern<GetStreamOp> {
     SmallVector<Value, 2> args;
     if (targetModel.getTargetArch() == AIEArch::AIE1)
       args.push_back(op.getChannel());
-    auto getSSCall = func::CallOp::create(rewriter, rewriter.getUnknownLoc(),
-                                          getSSFunc, args);
+    auto getSSCall =
+        func::CallOp::create(rewriter, op.getLoc(), getSSFunc, args);
     rewriter.replaceOp(op, getSSCall.getResult(0));
     // Capture TLAST in AIEv2?
     return success();
@@ -352,7 +352,7 @@ struct AIEPutCascadeToStdLowering : OpConversionPattern<PutCascadeOp> {
           rewriter, op.getLoc(), IntegerType::get(rewriter.getContext(), 32),
           rewriter.getI32IntegerAttr(1))); // enable
 
-    func::CallOp::create(rewriter, rewriter.getUnknownLoc(), putMCDFunc, args);
+    func::CallOp::create(rewriter, op.getLoc(), putMCDFunc, args);
     rewriter.eraseOp(op);
     return success();
   }
@@ -388,8 +388,8 @@ struct AIEGetCascadeToStdLowering : OpConversionPattern<GetCascadeOp> {
           rewriter, op.getLoc(), IntegerType::get(rewriter.getContext(), 32),
           rewriter.getI32IntegerAttr(1))); // enable
 
-    auto getSCDCall = func::CallOp::create(rewriter, rewriter.getUnknownLoc(),
-                                           getSCDFunc, args);
+    auto getSCDCall =
+        func::CallOp::create(rewriter, op.getLoc(), getSCDFunc, args);
     Value result = getSCDCall.getResult(0);
 
     // Check if we need a bitcast
@@ -459,8 +459,7 @@ struct AIEUseLockToStdLowering : OpConversionPattern<UseLockOp> {
                                     IntegerType::get(rewriter.getContext(), 32),
                                     rewriter.getI32IntegerAttr(lockValue)));
 
-      func::CallOp::create(rewriter, rewriter.getUnknownLoc(), useLockFunc,
-                           args);
+      func::CallOp::create(rewriter, useLock.getLoc(), useLockFunc, args);
     }
     rewriter.eraseOp(useLock);
     return success();
@@ -490,7 +489,7 @@ struct AIEBufferToStandard : OpConversionPattern<BufferOp> {
     // prevent duplication in the data section of the elf/object file)
     if ((tileRow != row && tileRow != -1) || (tileCol != col && tileCol != -1))
       initValue = nullptr;
-    memref::GlobalOp::create(rewriter, rewriter.getUnknownLoc(), symName,
+    memref::GlobalOp::create(rewriter, buffer.getLoc(), symName,
                              rewriter.getStringAttr("public"), buffer.getType(),
                              initValue, /*constant*/ false,
                              /*alignment*/ nullptr);
@@ -498,11 +497,11 @@ struct AIEBufferToStandard : OpConversionPattern<BufferOp> {
     for (auto &use : make_early_inc_range(buffer.getResult().getUses())) {
       Operation *user = use.getOwner();
       rewriter.setInsertionPoint(user);
-      auto allocated = memref::GetGlobalOp::create(
-          rewriter, rewriter.getUnknownLoc(), t, symName);
+      auto allocated =
+          memref::GetGlobalOp::create(rewriter, buffer.getLoc(), t, symName);
       // Assume that buffers are aligned so they can be vectorized.
-      memref::AssumeAlignmentOp::create(rewriter, rewriter.getUnknownLoc(),
-                                        allocated, 32);
+      memref::AssumeAlignmentOp::create(rewriter, buffer.getLoc(), allocated,
+                                        32);
 
       use.set(allocated.getResult());
     }
@@ -547,7 +546,7 @@ struct AIECoreToStandardFunc : OpConversionPattern<CoreOp> {
     std::string coreName("core_" + std::to_string(col) + "_" +
                          std::to_string(row));
     auto coreFunc =
-        func::FuncOp::create(rewriter, rewriter.getUnknownLoc(), coreName,
+        func::FuncOp::create(rewriter, op.getLoc(), coreName,
                              FunctionType::get(rewriter.getContext(), {}, {}));
 
     rewriter.cloneRegionBefore(op.getBody(), coreFunc.getBody(),
@@ -641,8 +640,7 @@ struct AIECoreToStandardFunc : OpConversionPattern<CoreOp> {
       rewriter.setInsertionPointAfter(childOp);
 
       if (isa<EndOp>(childOp)) {
-        func::ReturnOp::create(rewriter, rewriter.getUnknownLoc(),
-                               ValueRange({}));
+        func::ReturnOp::create(rewriter, childOp->getLoc(), ValueRange({}));
         rewriter.eraseOp(childOp);
       }
     });
@@ -701,7 +699,7 @@ struct AIEEventOpToStdLowering : OpConversionPattern<EventOp> {
     if (!eventFunc)
       return op.emitOpError("Could not find the intrinsic function ")
              << funcName;
-    func::CallOp::create(rewriter, rewriter.getUnknownLoc(), eventFunc, args);
+    func::CallOp::create(rewriter, op.getLoc(), eventFunc, args);
     rewriter.eraseOp(op);
     return success();
   }

--- a/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIECreatePathFindFlows.cpp
@@ -46,8 +46,8 @@ struct ConvertFlowsToInterconnect : OpConversionPattern<FlowOp> {
     auto point = rewriter.saveInsertionPoint();
     rewriter.setInsertionPoint(b.getTerminator());
 
-    ConnectOp::create(rewriter, rewriter.getUnknownLoc(), inBundle, inIndex,
-                      outBundle, outIndex);
+    ConnectOp::create(rewriter, flowOp.getLoc(), inBundle, inIndex, outBundle,
+                      outIndex);
 
     rewriter.restoreInsertionPoint(point);
 
@@ -832,13 +832,13 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
     Operation *tileOp = map.second;
     TileOp tile = cast<TileOp>(map.second);
     TileID tileId = tile.getTileID();
+    Location tileLoc = tile.getLoc();
 
     // Create a switchbox for the routes and insert inside it.
     builder.setInsertionPointAfter(tileOp);
     SwitchboxOp swbox =
         analyzer.getSwitchbox(builder, tile.colIndex(), tile.rowIndex());
-    SwitchboxOp::ensureTerminator(swbox.getConnections(), builder,
-                                  builder.getUnknownLoc());
+    SwitchboxOp::ensureTerminator(swbox.getConnections(), builder, tileLoc);
     Block &b = swbox.getConnections().front();
     builder.setInsertionPoint(b.getTerminator());
 
@@ -859,8 +859,7 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         if (amselOpNeededVector[amselValue]) {
           int arbiterID = a;
           int msel = i;
-          auto amsel = AMSelOp::create(builder, builder.getUnknownLoc(),
-                                       arbiterID, msel);
+          auto amsel = AMSelOp::create(builder, tileLoc, arbiterID, msel);
           amselOps[amselValue] = amsel;
         }
       }
@@ -885,8 +884,8 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
         amsels.push_back(amselOps[msel]);
       }
 
-      MasterSetOp::create(builder, builder.getUnknownLoc(),
-                          builder.getIndexType(), bundle, channel, amsels,
+      MasterSetOp::create(builder, tileLoc, builder.getIndexType(), bundle,
+                          channel, amsels,
                           keepPktHeaderAttr[{tileId, tileMaster}]);
     }
 
@@ -915,10 +914,9 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
 
       PacketRulesOp packetrules;
       if (slaveRules.count(slave) == 0) {
-        packetrules = PacketRulesOp::create(builder, builder.getUnknownLoc(),
-                                            bundle, channel);
+        packetrules = PacketRulesOp::create(builder, tileLoc, bundle, channel);
         PacketRulesOp::ensureTerminator(packetrules.getRules(), builder,
-                                        builder.getUnknownLoc());
+                                        tileLoc);
         slaveRules[slave] = packetrules;
       } else
         packetrules = slaveRules[slave];
@@ -939,7 +937,7 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
       }
 
       builder.setInsertionPoint(rules.getTerminator());
-      PacketRuleOp::create(builder, builder.getUnknownLoc(), mask, ID, amsel);
+      PacketRuleOp::create(builder, tileLoc, mask, ID, amsel);
     }
   }
 
@@ -996,13 +994,13 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
           pktrules.setSourceBundle(WireBundle::South);
           if (pktrules.getSourceChannel() == 0) {
             pktrules.setSourceChannel(3);
-            ConnectOp::create(builder, builder.getUnknownLoc(), WireBundle::DMA,
-                              0, WireBundle::North, 3);
+            ConnectOp::create(builder, tileOp.getLoc(), WireBundle::DMA, 0,
+                              WireBundle::North, 3);
           }
           if (pktrules.getSourceChannel() == 1) {
             pktrules.setSourceChannel(7);
-            ConnectOp::create(builder, builder.getUnknownLoc(), WireBundle::DMA,
-                              1, WireBundle::North, 7);
+            ConnectOp::create(builder, tileOp.getLoc(), WireBundle::DMA, 1,
+                              WireBundle::North, 7);
           }
         }
       }
@@ -1027,13 +1025,13 @@ AIEPathfinderPass::runOnPacketFlow(DeviceOp device, OpBuilder &builder,
           mtset.setDestBundle(WireBundle::South);
           if (mtset.getDestChannel() == 0) {
             mtset.setDestChannel(2);
-            ConnectOp::create(builder, builder.getUnknownLoc(),
-                              WireBundle::North, 2, WireBundle::DMA, 0);
+            ConnectOp::create(builder, tileOp.getLoc(), WireBundle::North, 2,
+                              WireBundle::DMA, 0);
           }
           if (mtset.getDestChannel() == 1) {
             mtset.setDestChannel(3);
-            ConnectOp::create(builder, builder.getUnknownLoc(),
-                              WireBundle::North, 3, WireBundle::DMA, 1);
+            ConnectOp::create(builder, tileOp.getLoc(), WireBundle::North, 3,
+                              WireBundle::DMA, 1);
           }
         }
       }
@@ -1084,54 +1082,55 @@ void AIEPathfinderPass::runOnOperation() {
         sw = analyzer.coordToSwitchbox[{col, row}];
       else
         continue;
+      Location loc = tile.getLoc();
       if (col > 0) {
         // connections east-west between stream switches
         if (analyzer.coordToSwitchbox.count({col - 1, row})) {
           auto westsw = analyzer.coordToSwitchbox[{col - 1, row}];
-          WireOp::create(builder, builder.getUnknownLoc(), westsw,
-                         WireBundle::East, sw, WireBundle::West);
+          WireOp::create(builder, loc, westsw, WireBundle::East, sw,
+                         WireBundle::West);
         }
       }
       if (row > 0) {
         // connections between abstract 'core' of tile
-        WireOp::create(builder, builder.getUnknownLoc(), tile, WireBundle::Core,
-                       sw, WireBundle::Core);
+        WireOp::create(builder, loc, tile, WireBundle::Core, sw,
+                       WireBundle::Core);
         // connections between abstract 'dma' of tile
-        WireOp::create(builder, builder.getUnknownLoc(), tile, WireBundle::DMA,
-                       sw, WireBundle::DMA);
+        WireOp::create(builder, loc, tile, WireBundle::DMA, sw,
+                       WireBundle::DMA);
         // connections north-south inside array ( including connection to shim
         // row)
         if (analyzer.coordToSwitchbox.count({col, row - 1})) {
           auto southsw = analyzer.coordToSwitchbox[{col, row - 1}];
-          WireOp::create(builder, builder.getUnknownLoc(), southsw,
-                         WireBundle::North, sw, WireBundle::South);
+          WireOp::create(builder, loc, southsw, WireBundle::North, sw,
+                         WireBundle::South);
         }
       } else if (row == 0) {
         if (tile.isShimNOCTile()) {
           if (analyzer.coordToShimMux.count({col, 0})) {
             auto shimsw = analyzer.coordToShimMux[{col, 0}];
             WireOp::create(
-                builder, builder.getUnknownLoc(), shimsw,
+                builder, loc, shimsw,
                 WireBundle::North, // Changed to connect into the north
                 sw, WireBundle::South);
             // PLIO is attached to shim mux
             if (analyzer.coordToPLIO.count(col)) {
               auto plio = analyzer.coordToPLIO[col];
-              WireOp::create(builder, builder.getUnknownLoc(), plio,
-                             WireBundle::North, shimsw, WireBundle::South);
+              WireOp::create(builder, loc, plio, WireBundle::North, shimsw,
+                             WireBundle::South);
             }
 
             // abstract 'DMA' connection on tile is attached to shim mux ( in
             // row 0 )
-            WireOp::create(builder, builder.getUnknownLoc(), tile,
-                           WireBundle::DMA, shimsw, WireBundle::DMA);
+            WireOp::create(builder, loc, tile, WireBundle::DMA, shimsw,
+                           WireBundle::DMA);
           }
         } else if (tile.isShimPLTile()) {
           // PLIO is attached directly to switch
           if (analyzer.coordToPLIO.count(col)) {
             auto plio = analyzer.coordToPLIO[col];
-            WireOp::create(builder, builder.getUnknownLoc(), plio,
-                           WireBundle::North, sw, WireBundle::South);
+            WireOp::create(builder, loc, plio, WireBundle::North, sw,
+                           WireBundle::South);
           }
         }
       }

--- a/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEGenerateColumnControlOverlay.cpp
@@ -201,8 +201,8 @@ struct AIEGenerateColumnControlOverlayPass
     }
   }
 
-  AIE::PacketFlowOp createPacketFlowOp(OpBuilder &builder, int &flowID,
-                                       Value source,
+  AIE::PacketFlowOp createPacketFlowOp(OpBuilder &builder, Location loc,
+                                       int &flowID, Value source,
                                        xilinx::AIE::WireBundle sourceBundle,
                                        uint32_t sourceChannel, Value dest,
                                        xilinx::AIE::WireBundle destBundle,
@@ -211,17 +211,15 @@ struct AIEGenerateColumnControlOverlayPass
                                        mlir::BoolAttr ctrl_pkt_flow = nullptr) {
     OpBuilder::InsertionGuard guard(builder);
 
-    AIE::PacketFlowOp pktFlow =
-        AIE::PacketFlowOp::create(builder, builder.getUnknownLoc(), flowID++,
-                                  keep_pkt_header, ctrl_pkt_flow);
+    AIE::PacketFlowOp pktFlow = AIE::PacketFlowOp::create(
+        builder, loc, flowID++, keep_pkt_header, ctrl_pkt_flow);
     Region &r_pktFlow = pktFlow.getPorts();
     Block *b_pktFlow = builder.createBlock(&r_pktFlow);
     builder.setInsertionPointToStart(b_pktFlow);
-    AIE::PacketSourceOp::create(builder, builder.getUnknownLoc(), source,
-                                sourceBundle, sourceChannel);
-    AIE::PacketDestOp::create(builder, builder.getUnknownLoc(), dest,
-                              destBundle, destChannel);
-    AIE::EndOp::create(builder, builder.getUnknownLoc());
+    AIE::PacketSourceOp::create(builder, loc, source, sourceBundle,
+                                sourceChannel);
+    AIE::PacketDestOp::create(builder, loc, dest, destBundle, destChannel);
+    AIE::EndOp::create(builder, loc);
     return pktFlow;
   }
 
@@ -299,14 +297,14 @@ struct AIEGenerateColumnControlOverlayPass
       auto ctrl_pkt_flow = builder.getBoolAttr(true);
       if (isShimMM2S)
         (void)createPacketFlowOp(
-            builder, ctrlPktFlowID, shimTile, shimWireBundle,
+            builder, tOp.getLoc(), ctrlPktFlowID, shimTile, shimWireBundle,
             rowToShimChanMap[tOp.rowIndex()], tOp, ctrlWireBundle,
             coreOrMemChanId, keep_pkt_header, ctrl_pkt_flow);
       else
-        (void)createPacketFlowOp(builder, ctrlPktFlowID, tOp, ctrlWireBundle,
-                                 coreOrMemChanId, shimTile, shimWireBundle,
-                                 rowToShimChanMap[tOp.rowIndex()],
-                                 keep_pkt_header, ctrl_pkt_flow);
+        (void)createPacketFlowOp(
+            builder, tOp.getLoc(), ctrlPktFlowID, tOp, ctrlWireBundle,
+            coreOrMemChanId, shimTile, shimWireBundle,
+            rowToShimChanMap[tOp.rowIndex()], keep_pkt_header, ctrl_pkt_flow);
 
       // Generate shim dma alloc ops as handle for runtime sequence to pickup,
       // when issuing control packets
@@ -327,9 +325,8 @@ struct AIEGenerateColumnControlOverlayPass
         continue;
 
       AIE::ShimDMAAllocationOp::create(
-          builder, builder.getUnknownLoc(), StringRef(dma_name),
-          shimTile.getResult(), dir, rowToShimChanMap[tOp.rowIndex()], false,
-          nullptr);
+          builder, tOp.getLoc(), StringRef(dma_name), shimTile.getResult(), dir,
+          rowToShimChanMap[tOp.rowIndex()], false, nullptr);
     }
   }
 

--- a/lib/Dialect/AIE/Transforms/AIELocalizeLocks.cpp
+++ b/lib/Dialect/AIE/Transforms/AIELocalizeLocks.cpp
@@ -80,7 +80,7 @@ struct AIELocalizeLocksPass
                 OpBuilder::atBlockBegin(&coreOp.getBody().front());
 
             Value coreLockIDValue = arith::ConstantIndexOp::create(
-                builder, builder.getUnknownLoc(), localLockIndex);
+                builder, lock.getLoc(), localLockIndex);
             lock.getResult().replaceUsesWithIf(
                 coreLockIDValue, [&](OpOperand &opOperand) {
                   return opOperand.getOwner()->getParentOp() == coreOp;

--- a/lib/Dialect/AIE/Transforms/AIELowerCascadeFlows.cpp
+++ b/lib/Dialect/AIE/Transforms/AIELowerCascadeFlows.cpp
@@ -79,7 +79,7 @@ struct AIELowerCascadeFlowsPass
       } else {
         outputDir = WireBundle::South;
       }
-      ConfigureCascadeOp::create(builder, builder.getUnknownLoc(), tile,
+      ConfigureCascadeOp::create(builder, tile.getLoc(), tile,
                                  static_cast<CascadeDir>(inputDir),
                                  static_cast<CascadeDir>(outputDir));
     }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoRegisterProcess.cpp
@@ -42,15 +42,15 @@ struct AIEObjectFifoRegisterProcessPass
     : xilinx::AIE::impl::AIEObjectFifoRegisterProcessBase<
           AIEObjectFifoRegisterProcessPass> {
 
-  scf::ForOp createForLoop(OpBuilder &builder, int length) {
-    auto lowerBound = arith::ConstantOp::create(
-        builder, builder.getUnknownLoc(), builder.getIndexAttr(0));
-    auto upperBound = arith::ConstantOp::create(
-        builder, builder.getUnknownLoc(), builder.getIndexAttr(length));
-    auto step = arith::ConstantOp::create(builder, builder.getUnknownLoc(),
-                                          builder.getIndexAttr(1));
-    auto forLoop = scf::ForOp::create(builder, builder.getUnknownLoc(),
-                                      lowerBound, upperBound, step);
+  scf::ForOp createForLoop(OpBuilder &builder, Location loc, int length) {
+    auto lowerBound =
+        arith::ConstantOp::create(builder, loc, builder.getIndexAttr(0));
+    auto upperBound =
+        arith::ConstantOp::create(builder, loc, builder.getIndexAttr(length));
+    auto step =
+        arith::ConstantOp::create(builder, loc, builder.getIndexAttr(1));
+    auto forLoop =
+        scf::ForOp::create(builder, loc, lowerBound, upperBound, step);
     return forLoop;
   }
 
@@ -58,10 +58,11 @@ struct AIEObjectFifoRegisterProcessPass
                      ObjectFifoRegisterProcessOp regOp, MemRefType elementType,
                      IntegerAttr acqNumber, IntegerAttr relNumber, int length) {
     auto ctx = device->getContext();
+    Location loc = regOp.getLoc();
     // create for loop
     scf::ForOp forLoop;
     if (length > 1) {
-      forLoop = createForLoop(builder, length);
+      forLoop = createForLoop(builder, loc, length);
       Region &forRegion = forLoop.getRegion();
       builder.setInsertionPointToStart(&forRegion.back());
     }
@@ -70,13 +71,13 @@ struct AIEObjectFifoRegisterProcessPass
     if (acqNumber.getInt() > 0) {
       auto acqType = AIEObjectFifoSubviewType::get(elementType);
       auto acqOp = ObjectFifoAcquireOp::create(
-          builder, builder.getUnknownLoc(), acqType, regOp.getPortAttr(),
+          builder, loc, acqType, regOp.getPortAttr(),
           SymbolRefAttr::get(ctx, regOp.getObjFifoName()), acqNumber);
 
       // subview accesses
       for (int i = 0; i < acqNumber.getInt(); i++)
         (void)ObjectFifoSubviewAccessOp::create(
-            builder, builder.getUnknownLoc(), elementType, acqOp.getSubview(),
+            builder, loc, elementType, acqOp.getSubview(),
             builder.getIntegerAttr(builder.getI32Type(), i));
 
       // apply kernel
@@ -87,14 +88,13 @@ struct AIEObjectFifoRegisterProcessPass
           break;
         }
       }
-      func::CallOp::create(builder, builder.getUnknownLoc(),
-                           func /*, acc.output()*/);
+      func::CallOp::create(builder, loc, func /*, acc.output()*/);
     }
 
     // releases
     if (relNumber.getInt() > 0) {
       auto relOp = ObjectFifoReleaseOp::create(
-          builder, builder.getUnknownLoc(), regOp.getPortAttr(),
+          builder, loc, regOp.getPortAttr(),
           SymbolRefAttr::get(ctx, regOp.getObjFifoName()), relNumber);
       builder.setInsertionPointAfter(relOp);
     }
@@ -143,13 +143,13 @@ struct AIEObjectFifoRegisterProcessPass
           /*AllowRepeats=*/false);
       // retrieve core associated to above tile or create new one
       if (!op) {
-        CoreOp coreOp = CoreOp::create(builder, builder.getUnknownLoc(),
+        CoreOp coreOp = CoreOp::create(builder, registerOp.getLoc(),
                                        builder.getIndexType(), tile);
         Region &r = coreOp.getBody();
         r.push_back(new Block);
         Block &block = r.back();
         builder.setInsertionPointToStart(&block);
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, registerOp.getLoc());
         builder.setInsertionPointToStart(&block);
       } else {
         CoreOp coreOp = llvm::dyn_cast<CoreOp>(op);

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -375,14 +375,14 @@ struct AIEObjectFifoStatefulTransformPass
   }
 
   ObjectFifoCreateOp
-  createObjectFifo(OpBuilder &builder, AIEObjectFifoType datatype,
+  createObjectFifo(OpBuilder &builder, Location loc, AIEObjectFifoType datatype,
                    std::string name, Value prodTile, Value consTile,
                    Attribute depth, BDDimLayoutArrayAttr dimensionsToStream,
                    BDDimLayoutArrayArrayAttr dimensionsFromStreamPerConsumer) {
     auto ofName = builder.getStringAttr(name);
     auto fifo = ObjectFifoCreateOp::create(
-        builder, builder.getUnknownLoc(), ofName, prodTile, consTile, depth,
-        datatype, dimensionsToStream, dimensionsFromStreamPerConsumer);
+        builder, loc, ofName, prodTile, consTile, depth, datatype,
+        dimensionsToStream, dimensionsFromStreamPerConsumer);
     return fifo;
   }
 
@@ -411,14 +411,15 @@ struct AIEObjectFifoStatefulTransformPass
       if (!state.externalBuffersPerFifo[op].empty())
         numElem = state.externalBuffersPerFifo[op].size();
     }
+    Location ofLoc = op.getLoc();
     if (target.getTargetArch() == AIEArch::AIE1) {
       for (int i = 0; i < numElem; i++) {
         // create corresponding aie1 locks
         int initValue = op.getInitValues().has_value() ? 1 : 0;
         int lockID = lockAnalysis.getLockID(creation_tile);
         assert(lockID >= 0 && "No more locks to allocate!");
-        auto lock = LockOp::create(builder, builder.getUnknownLoc(),
-                                   creation_tile, lockID, initValue);
+        auto lock =
+            LockOp::create(builder, ofLoc, creation_tile, lockID, initValue);
         lock.getOperation()->setAttr(SymbolTable::getSymbolAttrName(),
                                      builder.getStringAttr(op.name().str() +
                                                            "_lock_" +
@@ -434,9 +435,8 @@ struct AIEObjectFifoStatefulTransformPass
         int prodLockID = lockAnalysis.getLockID(creation_tile);
         assert(prodLockID >= 0 && "No more locks to allocate!");
         int prodLockValue = (numElem - initValues) * repeatCount;
-        auto prodLock =
-            LockOp::create(builder, builder.getUnknownLoc(), creation_tile,
-                           prodLockID, prodLockValue);
+        auto prodLock = LockOp::create(builder, ofLoc, creation_tile,
+                                       prodLockID, prodLockValue);
         prodLock.getOperation()->setAttr(
             SymbolTable::getSymbolAttrName(),
             builder.getStringAttr(op.name().str() + "_prod_lock_" +
@@ -446,9 +446,8 @@ struct AIEObjectFifoStatefulTransformPass
         int consLockID = lockAnalysis.getLockID(creation_tile);
         assert(consLockID >= 0 && "No more locks to allocate!");
         int consLockValue = initValues * repeatCount;
-        auto consLock =
-            LockOp::create(builder, builder.getUnknownLoc(), creation_tile,
-                           consLockID, consLockValue);
+        auto consLock = LockOp::create(builder, ofLoc, creation_tile,
+                                       consLockID, consLockValue);
         consLock.getOperation()->setAttr(
             SymbolTable::getSymbolAttrName(),
             builder.getStringAttr(op.name().str() + "_cons_lock_" +
@@ -580,7 +579,7 @@ struct AIEObjectFifoStatefulTransformPass
     }
 
     builder.setInsertionPointAfter(insertAfter);
-    auto newTile = TileOp::create(builder, builder.getUnknownLoc(), col, row);
+    auto newTile = TileOp::create(builder, hostTile.getLoc(), col, row);
 
     builder.restoreInsertionPoint(savedInsertionPoint);
 
@@ -774,8 +773,7 @@ struct AIEObjectFifoStatefulTransformPass
           }
         }
         auto buff = BufferOp::create(
-            builder, builder.getUnknownLoc(), elemType,
-            current_buf_allocation_tile,
+            builder, op.getLoc(), elemType, current_buf_allocation_tile,
             builder.getStringAttr(op.name().str() + "_buff_" +
                                   std::to_string(of_elem_index)),
             /*address*/ nullptr, initValues,
@@ -817,31 +815,27 @@ struct AIEObjectFifoStatefulTransformPass
 
   /// Function used to create a Bd block.
   template <typename MyOp>
-  void createBd(OpBuilder &builder, LockOp acqLock, int acqMode,
+  void createBd(OpBuilder &builder, Location loc, LockOp acqLock, int acqMode,
                 LockAction acqLockAction, LockOp relLock, int relMode,
                 MyOp buff, int offset, int len, Block *succ,
                 BDDimLayoutArrayAttr dims, BDPadLayoutArrayAttr padDimensions,
                 std::optional<PacketInfoAttr> bdPacket) {
     if (acqLock)
-      UseLockOp::create(builder, builder.getUnknownLoc(), acqLock,
-                        acqLockAction, acqMode);
+      UseLockOp::create(builder, loc, acqLock, acqLockAction, acqMode);
     if (bdPacket) {
-      DMABDPACKETOp::create(builder, builder.getUnknownLoc(),
-                            bdPacket->getPktType(), bdPacket->getPktId());
+      DMABDPACKETOp::create(builder, loc, bdPacket->getPktType(),
+                            bdPacket->getPktId());
     }
     if (!dims.getValue().empty() && padDimensions) {
-      DMABDOp::create(builder, builder.getUnknownLoc(), buff, offset, len, dims,
-                      padDimensions);
+      DMABDOp::create(builder, loc, buff, offset, len, dims, padDimensions);
     } else if (!dims.getValue().empty()) {
-      DMABDOp::create(builder, builder.getUnknownLoc(), buff, offset, len,
-                      dims);
+      DMABDOp::create(builder, loc, buff, offset, len, dims);
     } else {
-      DMABDOp::create(builder, builder.getUnknownLoc(), buff, offset, len);
+      DMABDOp::create(builder, loc, buff, offset, len);
     }
     if (acqLock)
-      UseLockOp::create(builder, builder.getUnknownLoc(), relLock,
-                        LockAction::Release, relMode);
-    NextBDOp::create(builder, builder.getUnknownLoc(), succ);
+      UseLockOp::create(builder, loc, relLock, LockAction::Release, relMode);
+    NextBDOp::create(builder, loc, succ);
   }
 
   /// Function used to create a Bd block.
@@ -886,8 +880,8 @@ struct AIEObjectFifoStatefulTransformPass
                       : state.locksPerFifo[op][prodLockIndex];
       }
     }
-    createBd(builder, acqLock, acqMode, acqLockAction, relLock, relMode, buff,
-             offset, len, succ, dims, padDimensions, bdPacket);
+    createBd(builder, op.getLoc(), acqLock, acqMode, acqLockAction, relLock,
+             relMode, buff, offset, len, succ, dims, padDimensions, bdPacket);
   }
 
   /// Function that either calls createAIETileDMA(), createShimDMA() or
@@ -965,12 +959,11 @@ struct AIEObjectFifoStatefulTransformPass
     if (producerMem == nullptr) {
       OpBuilder::InsertionGuard g(builder);
       builder.setInsertionPoint(device.getBody()->getTerminator());
-      auto newMemOp =
-          MemOp::create(builder, builder.getUnknownLoc(), objFifoTileOp);
+      auto newMemOp = MemOp::create(builder, op.getLoc(), objFifoTileOp);
       {
         OpBuilder::InsertionGuard g(builder);
         builder.setInsertionPointToStart(&newMemOp.getRegion().emplaceBlock());
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, op.getLoc());
       }
       producerMem = newMemOp.getOperation();
     }
@@ -986,8 +979,8 @@ struct AIEObjectFifoStatefulTransformPass
     int dmaRepeatCount = useHwRepeat ? repeatCount - 1 : 0;
     int bdRepeatCount = useHwRepeat ? 1 : repeatCount;
     builder.setInsertionPointToStart(dmaBlock);
-    DMAStartOp::create(builder, builder.getUnknownLoc(), channelDir,
-                       channelIndex, dmaRepeatCount, bdBlock, endBlock);
+    DMAStartOp::create(builder, op.getLoc(), channelDir, channelIndex,
+                       dmaRepeatCount, bdBlock, endBlock);
     if (lastDmaBlock != nullptr)
       lastDmaBlock->getTerminator()->setSuccessor(dmaBlock, 1);
 
@@ -1045,12 +1038,12 @@ struct AIEObjectFifoStatefulTransformPass
     if (producerDMA == nullptr) {
       OpBuilder::InsertionGuard g(builder);
       builder.setInsertionPoint(device.getBody()->getTerminator());
-      auto newDMAOp = ShimDMAOp::create(builder, builder.getUnknownLoc(),
+      auto newDMAOp = ShimDMAOp::create(builder, op.getLoc(),
                                         builder.getIndexType(), objFifoTileOp);
       {
         OpBuilder::InsertionGuard g(builder);
         builder.setInsertionPointToStart(&newDMAOp.getRegion().emplaceBlock());
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, op.getLoc());
       }
       producerDMA = newDMAOp.getOperation();
     }
@@ -1062,8 +1055,8 @@ struct AIEObjectFifoStatefulTransformPass
 
     // create DMA channel
     builder.setInsertionPointToStart(dmaBlock);
-    DMAStartOp::create(builder, builder.getUnknownLoc(), channelDir,
-                       channelIndex, /*repeatCout*/ 0, bdBlock, endBlock);
+    DMAStartOp::create(builder, op.getLoc(), channelDir, channelIndex,
+                       /*repeatCout*/ 0, bdBlock, endBlock);
     if (lastDmaBlock != nullptr)
       lastDmaBlock->getTerminator()->setSuccessor(dmaBlock, 1);
 
@@ -1208,12 +1201,11 @@ struct AIEObjectFifoStatefulTransformPass
     if (producerDMA == nullptr) {
       OpBuilder::InsertionGuard g(builder);
       builder.setInsertionPoint(device.getBody()->getTerminator());
-      auto newDMAOp =
-          MemTileDMAOp::create(builder, builder.getUnknownLoc(), objFifoTileOp);
+      auto newDMAOp = MemTileDMAOp::create(builder, op.getLoc(), objFifoTileOp);
       {
         OpBuilder::InsertionGuard g(builder);
         builder.setInsertionPointToStart(&newDMAOp.getRegion().emplaceBlock());
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, op.getLoc());
       }
       producerDMA = newDMAOp.getOperation();
     }
@@ -1239,8 +1231,8 @@ struct AIEObjectFifoStatefulTransformPass
     if (useHwRepeat)
       taskCount = repeatCount - 1;
     int bdRepeatFactor = useHwRepeat ? 1 : repeatCount;
-    DMAStartOp::create(builder, builder.getUnknownLoc(), channelDir,
-                       channelIndex, taskCount, bdBlock, endBlock);
+    DMAStartOp::create(builder, op.getLoc(), channelDir, channelIndex,
+                       taskCount, bdBlock, endBlock);
     if (lastDmaBlock != nullptr)
       lastDmaBlock->getTerminator()->setSuccessor(dmaBlock, 1);
 
@@ -1264,7 +1256,7 @@ struct AIEObjectFifoStatefulTransformPass
             // Create a separate terminating block with aie.end for this
             // specific DMA channel
             builder.setInsertionPointToStart(succ);
-            EndOp::create(builder, builder.getUnknownLoc());
+            EndOp::create(builder, op.getLoc());
           } else {
             succ = bdBlock;
           }
@@ -1431,9 +1423,9 @@ struct AIEObjectFifoStatefulTransformPass
                              BufferOp globalNextIndex, arith::ConstantOp index,
                              arith::ConstantOp size) {
     builder.setInsertionPointAfter(relOp);
-    Value oldCounter = memref::LoadOp::create(
-        builder, builder.getUnknownLoc(), globalNextIndex,
-        ValueRange(ArrayRef({index.getResult()})));
+    Value oldCounter =
+        memref::LoadOp::create(builder, relOp.getLoc(), globalNextIndex,
+                               ValueRange(ArrayRef({index.getResult()})));
     Value val =
         arith::ConstantOp::create(builder, oldCounter.getLoc(),
                                   builder.getI32IntegerAttr(relOp.getSize()));
@@ -1473,8 +1465,8 @@ struct AIEObjectFifoStatefulTransformPass
 
         int index = 0;
         builder.setInsertionPointToStart(&(coreOp.getBody().front()));
-        Value initVal = arith::ConstantOp::create(
-            builder, builder.getUnknownLoc(), builder.getI32IntegerAttr(0));
+        Value initVal = arith::ConstantOp::create(builder, coreOp.getLoc(),
+                                                  builder.getI32IntegerAttr(0));
         coreOp.walk([&](ObjectFifoAcquireOp acqOp) {
           ObjectFifoCreateOp op = acqOp.getObjectFifo();
           ObjectFifoPort port = acqOp.getPort();
@@ -1495,7 +1487,7 @@ struct AIEObjectFifoStatefulTransformPass
             MemRefType::get(SmallVector<int64_t>{(int64_t)fifoSizes.size()},
                             builder.getI32Type());
         auto globalNextIndex = BufferOp::create(
-            builder, builder.getUnknownLoc(), memrefTy, coreOp.getTile(),
+            builder, coreOp.getLoc(), memrefTy, coreOp.getTile(),
             /*sym_name*/ nullptr, /*address*/ nullptr,
             /*initial_value*/ nullptr, /*mem_bank*/ nullptr,
             /*aligned*/ nullptr);
@@ -1504,7 +1496,7 @@ struct AIEObjectFifoStatefulTransformPass
         for (auto i : constantSizes) {
           builder.setInsertionPointAfter(i.second);
           memref::StoreOp::create(
-              builder, builder.getUnknownLoc(), initVal, globalNextIndex,
+              builder, coreOp.getLoc(), initVal, globalNextIndex,
               ValueRange(ArrayRef({globalIndices[i.first].getResult()})));
         }
 
@@ -1539,11 +1531,11 @@ struct AIEObjectFifoStatefulTransformPass
               // Create a switch for each subview access
               builder.setInsertionPointAfter(accessOp);
               auto switchIndexAsInteger = memref::LoadOp::create(
-                  builder, builder.getUnknownLoc(), globalNextIndex,
+                  builder, acqOp.getLoc(), globalNextIndex,
                   ValueRange(
                       ArrayRef({globalIndices[{createOp, port}].getResult()})));
               auto switchIndex = arith::IndexCastOp::create(
-                  builder, builder.getUnknownLoc(), builder.getIndexType(),
+                  builder, acqOp.getLoc(), builder.getIndexType(),
                   switchIndexAsInteger);
               unsigned caseRegionCounts = fifoSizes[{createOp, port}];
               SmallVector<int64_t, 4> caseValues;
@@ -1561,7 +1553,7 @@ struct AIEObjectFifoStatefulTransformPass
               auto bufferIndex = (accessOp.getIndex()) % createOp.size();
               builder.setInsertionPointToStart(&(switchOp.getDefaultBlock()));
               scf::YieldOp::create(
-                  builder, builder.getUnknownLoc(),
+                  builder, accessOp.getLoc(),
                   state.buffersPerFifo[createOp][bufferIndex].getResult());
               for (int i = 0; i < fifoSizes[{createOp, port}]; ++i) {
                 // Create other cases of IndexSwitchOp
@@ -1625,7 +1617,7 @@ struct AIEObjectFifoStatefulTransformPass
         lockMode = 1;
       for (int i = 0; i < numLocks; i++) {
         int lockID = acc[{op, portNum}];
-        UseLockOp::create(builder, builder.getUnknownLoc(),
+        UseLockOp::create(builder, op.getLoc(),
                           state.locksPerFifo[target][lockID], lockAction,
                           lockMode);
         acc[{op, portNum}] =
@@ -1655,8 +1647,7 @@ struct AIEObjectFifoStatefulTransformPass
         else
           lock = state.locksPerFifo[target][0];
       }
-      UseLockOp::create(builder, builder.getUnknownLoc(), lock, lockAction,
-                        numLocks);
+      UseLockOp::create(builder, op.getLoc(), lock, lockAction, numLocks);
       acc[{op, portNum}] = (acc[{op, portNum}] + numLocks) %
                            op.size(); // update to next objFifo elem
     }
@@ -1768,7 +1759,7 @@ struct AIEObjectFifoStatefulTransformPass
     std::string alloc_name = getShimAllocationName(objFifoOp.getName());
     // SymbolRefAttr::get(ctx, objFifoOp.getName())
     ShimDMAAllocationOp::create(
-        builder, builder.getUnknownLoc(), StringAttr::get(ctx, alloc_name),
+        builder, objFifoOp.getLoc(), StringAttr::get(ctx, alloc_name),
         shimTile.getResult(), DMAChannelDirAttr::get(ctx, channelDir),
         builder.getI64IntegerAttr(channelIndex), builder.getBoolAttr(plio),
         packetInfo);
@@ -1930,9 +1921,10 @@ struct AIEObjectFifoStatefulTransformPass
             BDDimLayoutArrayArrayAttr::get(builder.getContext(),
                                            singletonFromStreamDims);
 
-        ObjectFifoCreateOp consumerFifo = createObjectFifo(
-            builder, datatype, consumerFifoName, consumerTile, consumerTile,
-            consumerObjFifoSize, emptyDims, fromStreamDims);
+        ObjectFifoCreateOp consumerFifo =
+            createObjectFifo(builder, createOp.getLoc(), datatype,
+                             consumerFifoName, consumerTile, consumerTile,
+                             consumerObjFifoSize, emptyDims, fromStreamDims);
         if (createOp.getDisableSynchronization())
           consumerFifo.setDisableSynchronization(true);
         // Propagate iter_count attribute from the original createOp
@@ -2095,14 +2087,14 @@ struct AIEObjectFifoStatefulTransformPass
           // create packet flow
           builder.setInsertionPointAfter(producer);
           packetflow = builder.create<PacketFlowOp>(
-              builder.getUnknownLoc(),
+              producer.getLoc(),
               builder.getIntegerAttr(builder.getI8Type(), bdPacket->getPktId()),
               nullptr, nullptr);
           {
             OpBuilder::InsertionGuard g(builder);
             builder.setInsertionPointToStart(
                 &packetflow.getRegion().emplaceBlock());
-            builder.create<EndOp>(builder.getUnknownLoc());
+            builder.create<EndOp>(producer.getLoc());
           }
         }
       }
@@ -2146,7 +2138,7 @@ struct AIEObjectFifoStatefulTransformPass
 
           if (clPacketSwObjectFifos) {
             builder.setInsertionPointToStart(&packetflow.getPorts().front());
-            builder.create<PacketDestOp>(builder.getUnknownLoc(),
+            builder.create<PacketDestOp>(consumer.getLoc(),
                                          consumer.getProducerTile(),
                                          WireBundle::DMA, consumerChan.channel);
           }
@@ -2178,16 +2170,16 @@ struct AIEObjectFifoStatefulTransformPass
         if (!clPacketSwObjectFifos) {
           // create flow
           builder.setInsertionPointAfter(producer);
-          FlowOp::create(builder, builder.getUnknownLoc(),
-                         producer.getProducerTile(), producerWireType,
-                         producerChan.channel, consumer.getProducerTile(),
-                         consumerWireType, consumerChan.channel);
+          FlowOp::create(builder, producer.getLoc(), producer.getProducerTile(),
+                         producerWireType, producerChan.channel,
+                         consumer.getProducerTile(), consumerWireType,
+                         consumerChan.channel);
         }
       }
 
       if (clPacketSwObjectFifos) {
         builder.setInsertionPointToStart(&packetflow.getPorts().front());
-        PacketSourceOp::create(builder, builder.getUnknownLoc(),
+        PacketSourceOp::create(builder, producer.getLoc(),
                                producer.getProducerTile(), WireBundle::DMA,
                                producerChan.channel);
       }

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -378,11 +378,13 @@ struct AIEObjectFifoStatefulTransformPass
   createObjectFifo(OpBuilder &builder, Location loc, AIEObjectFifoType datatype,
                    std::string name, Value prodTile, Value consTile,
                    Attribute depth, BDDimLayoutArrayAttr dimensionsToStream,
-                   BDDimLayoutArrayArrayAttr dimensionsFromStreamPerConsumer) {
+                   BDDimLayoutArrayArrayAttr dimensionsFromStreamPerConsumer,
+                   Location loc = {}) {
     auto ofName = builder.getStringAttr(name);
     auto fifo = ObjectFifoCreateOp::create(
-        builder, loc, ofName, prodTile, consTile, depth, datatype,
-        dimensionsToStream, dimensionsFromStreamPerConsumer);
+        builder, loc ? loc : builder.getUnknownLoc(), ofName, prodTile,
+        consTile, depth, datatype, dimensionsToStream,
+        dimensionsFromStreamPerConsumer);
     return fifo;
   }
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -382,9 +382,8 @@ struct AIEObjectFifoStatefulTransformPass
                    Location loc = {}) {
     auto ofName = builder.getStringAttr(name);
     auto fifo = ObjectFifoCreateOp::create(
-        builder, loc ? loc : builder.getUnknownLoc(), ofName, prodTile,
-        consTile, depth, datatype, dimensionsToStream,
-        dimensionsFromStreamPerConsumer);
+        builder, loc, ofName, prodTile, consTile, depth, datatype,
+        dimensionsToStream, dimensionsFromStreamPerConsumer);
     return fifo;
   }
 

--- a/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
+++ b/lib/Dialect/AIE/Transforms/AIEObjectFifoStatefulTransform.cpp
@@ -378,8 +378,7 @@ struct AIEObjectFifoStatefulTransformPass
   createObjectFifo(OpBuilder &builder, Location loc, AIEObjectFifoType datatype,
                    std::string name, Value prodTile, Value consTile,
                    Attribute depth, BDDimLayoutArrayAttr dimensionsToStream,
-                   BDDimLayoutArrayArrayAttr dimensionsFromStreamPerConsumer,
-                   Location loc = {}) {
+                   BDDimLayoutArrayArrayAttr dimensionsFromStreamPerConsumer) {
     auto ofName = builder.getStringAttr(name);
     auto fifo = ObjectFifoCreateOp::create(
         builder, loc, ofName, prodTile, consTile, depth, datatype,

--- a/lib/Dialect/AIE/Util/AIELocCheckpoint.cpp
+++ b/lib/Dialect/AIE/Util/AIELocCheckpoint.cpp
@@ -1,0 +1,42 @@
+//===- AIELocCheckpoint.cpp --------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+//
+//===----------------------------------------------------------------------===//
+
+#include "aie/Dialect/AIE/Util/AIELocCheckpoint.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/MLIRContext.h"
+
+using namespace mlir;
+
+namespace xilinx::AIE {
+
+Location fuseStageLabel(Location loc, llvm::StringRef stage) {
+  MLIRContext *ctx = loc.getContext();
+  std::string label = (getCheckpointMetadataPrefix().str() + stage.str());
+  StringAttr metadata = StringAttr::get(ctx, label);
+
+  // Idempotent: if the top-level metadata already matches, no-op.
+  if (auto fused = dyn_cast<FusedLoc>(loc))
+    if (auto existing = dyn_cast_or_null<StringAttr>(fused.getMetadata()))
+      if (existing == metadata)
+        return loc;
+
+  return FusedLoc::get(ctx, {loc}, metadata);
+}
+
+void applyStageLabel(Operation *op, llvm::StringRef stage) {
+  if (!op)
+    return;
+  op->walk([&](Operation *child) {
+    child->setLoc(fuseStageLabel(child->getLoc(), stage));
+  });
+}
+
+} // namespace xilinx::AIE

--- a/lib/Dialect/AIE/Util/AIERegisterDatabase.cpp
+++ b/lib/Dialect/AIE/Util/AIERegisterDatabase.cpp
@@ -81,6 +81,7 @@ std::unique_ptr<RegisterDatabase> RegisterDatabase::loadAIE2() {
   auto db = std::unique_ptr<RegisterDatabase>(new RegisterDatabase());
   if (!db->loadFromJSON(*registerPath, *eventPath))
     return nullptr;
+  db->buildOffsetIndex();
 
   return db;
 }
@@ -259,6 +260,30 @@ const RegisterInfo *RegisterDatabase::lookupRegister(StringRef name,
   std::transform(key.begin(), key.end(), key.begin(), ::tolower);
   auto it = registers_.find(key);
   return it != registers_.end() ? &it->second : nullptr;
+}
+
+void RegisterDatabase::buildOffsetIndex() {
+  registersByOffset_.clear();
+  for (const auto &entry : registers_) {
+    const RegisterInfo &info = entry.second;
+    std::string moduleKey = info.module;
+    std::transform(moduleKey.begin(), moduleKey.end(), moduleKey.begin(),
+                   ::tolower);
+    registersByOffset_[moduleKey][info.offset] = &info;
+  }
+}
+
+const RegisterInfo *
+RegisterDatabase::lookupRegisterByOffset(uint32_t offset,
+                                         StringRef module) const {
+  std::string moduleKey = module.lower();
+  auto modIt = registersByOffset_.find(moduleKey);
+  if (modIt == registersByOffset_.end())
+    return nullptr;
+  auto offIt = modIt->second.find(offset);
+  if (offIt == modIt->second.end())
+    return nullptr;
+  return offIt->second;
 }
 
 std::optional<uint32_t> RegisterDatabase::lookupEvent(StringRef name,

--- a/lib/Dialect/AIE/Util/CMakeLists.txt
+++ b/lib/Dialect/AIE/Util/CMakeLists.txt
@@ -27,6 +27,7 @@ endforeach()
 add_custom_target(MLIRAIERegDBResources ALL DEPENDS ${AIE_REGDB_OUTPUTS})
 
 add_mlir_dialect_library(MLIRAIEUtil
+  AIELocCheckpoint.cpp
   AIERegisterDatabase.cpp
 
   ADDITIONAL_HEADER_DIRS
@@ -34,6 +35,7 @@ add_mlir_dialect_library(MLIRAIEUtil
 
   LINK_LIBS PUBLIC
   MLIRSupport
+  MLIRIR
 )
 
 add_dependencies(MLIRAIEUtil MLIRAIERegDBResources GenerateAIEEventsTD)

--- a/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateBroadcastPacket.cpp
@@ -72,11 +72,11 @@ struct AIEBroadcastPacketPass
           int flowID = bpid.IDInt();
           builder.setInsertionPointAfter(broadcastpacket);
           PacketFlowOp pkFlow = PacketFlowOp::create(
-              builder, builder.getUnknownLoc(), flowID, nullptr, nullptr);
+              builder, broadcastpacket.getLoc(), flowID, nullptr, nullptr);
           Region &r_pkFlow = pkFlow.getPorts();
           Block *b_pkFlow = builder.createBlock(&r_pkFlow);
           builder.setInsertionPointToStart(b_pkFlow);
-          PacketSourceOp::create(builder, builder.getUnknownLoc(), srcTile,
+          PacketSourceOp::create(builder, broadcastpacket.getLoc(), srcTile,
                                  sourcePort.bundle, sourcePort.channel);
           for (Operation &op : b_bpid.getOperations()) {
             if (BPDestOp bpdest = dyn_cast<BPDestOp>(op)) {
@@ -84,12 +84,12 @@ struct AIEBroadcastPacketPass
                   dyn_cast<TileOp>(bpdest.getTile().getDefiningOp());
               Port destPort = bpdest.port();
               builder.setInsertionPointToEnd(b_pkFlow);
-              PacketDestOp::create(builder, builder.getUnknownLoc(), destTile,
+              PacketDestOp::create(builder, bpdest.getLoc(), destTile,
                                    destPort.bundle, destPort.channel);
             }
           }
           builder.setInsertionPointToEnd(b_pkFlow);
-          EndOp::create(builder, builder.getUnknownLoc());
+          EndOp::create(builder, broadcastpacket.getLoc());
         }
       }
     }

--- a/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateCores.cpp
@@ -106,8 +106,8 @@ struct AIECreateCoresPass
       // get or create TileOp
       if (!tiles[{colIndex, rowIndex}]) {
         builder.setInsertionPointToStart(device.getBody());
-        TileOp tile = TileOp::create(builder, builder.getUnknownLoc(), colIndex,
-                                     rowIndex);
+        TileOp tile =
+            TileOp::create(builder, callOp.getLoc(), colIndex, rowIndex);
         tiles[{colIndex, rowIndex}] = tile;
       }
       Operation *tileOp = tiles[{colIndex, rowIndex}];
@@ -130,21 +130,21 @@ struct AIECreateCoresPass
           assert(t && "Unsupported type!");
           coreBufTypes.push_back({t, i});
           BufferOp buf = BufferOp::create(
-              builder, builder.getUnknownLoc(), t, tile, /*sym_name*/ nullptr,
+              builder, callOp.getLoc(), t, tile, /*sym_name*/ nullptr,
               /*address*/ nullptr, /*initial_value*/ nullptr,
               /*mem_bank*/ nullptr, /*aligned*/ nullptr);
           buffers[callOperands[i]] = buf;
           operand.replaceAllUsesWith(buf.getResult());
         }
 
-        MemOp mem = MemOp::create(builder, builder.getUnknownLoc(),
+        MemOp mem = MemOp::create(builder, callOp.getLoc(),
                                   builder.getIndexType(), tile);
         Region &r = mem.getBody();
         Block *endBlock = builder.createBlock(&r);
 
         // block terminator
         builder.setInsertionPointToStart(endBlock);
-        EndOp::create(builder, builder.getUnknownLoc());
+        EndOp::create(builder, callOp.getLoc());
         mems[tileOp] = mem;
       }
 
@@ -163,7 +163,7 @@ struct AIECreateCoresPass
           Block *currentBlock;
 
           if (!cores[tileOp]) {
-            core = CoreOp::create(builder, builder.getUnknownLoc(), tile);
+            core = CoreOp::create(builder, callOp.getLoc(), tile);
             Region &r = core.getBody();
             currentBlock = builder.createBlock(&r);
             builder.setInsertionPointToStart(currentBlock);
@@ -187,10 +187,10 @@ struct AIECreateCoresPass
               assert(pair.first.getShape()[0] == 1 &&
                      "Expected MemRefType of single element");
 
-              Value zero = arith::ConstantIndexOp::create(
-                  builder, builder.getUnknownLoc(), 0);
-              auto loadOp = memref::LoadOp::create(
-                  builder, builder.getUnknownLoc(), arg.getType(), buf, zero);
+              Value zero =
+                  arith::ConstantIndexOp::create(builder, callOp.getLoc(), 0);
+              auto loadOp = memref::LoadOp::create(builder, callOp.getLoc(),
+                                                   arg.getType(), buf, zero);
               mapper.map(arg, loadOp);
             } else {
               mapper.map(arg, buf);
@@ -207,7 +207,7 @@ struct AIECreateCoresPass
           }
           if (!cores[tileOp]) {
             // block terminator
-            EndOp::create(builder, builder.getUnknownLoc());
+            EndOp::create(builder, callOp.getLoc());
             cores[tileOp] = core;
           }
         }
@@ -233,7 +233,7 @@ struct AIECreateCoresPass
     //          "Could not allocate more than two dest. channel when creating
     //          FlowOp");
     //   // WireBundle[1] = DMA
-    //   FlowOp::create(builder, builder.getUnknownLoc(), srcTile, 1, 0,
+    //   FlowOp::create(builder, callOp.getLoc(), srcTile, 1, 0,
     //   dstTile, 1, destChannel[op.dstTile()]); destChannel[op.dstTile()]++;
     // }
 

--- a/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECreateLocks.cpp
@@ -200,8 +200,7 @@ struct AIECreateLocksPass
       LLVM_DEBUG(llvm::dbgs() << "Shared tile \n"; tileOp->print(llvm::dbgs()));
       LLVM_DEBUG(llvm::dbgs() << " LockID: " << lockID << '\n');
       builder.setInsertionPointAfter(tileOp);
-      LockOp lock =
-          LockOp::create(builder, builder.getUnknownLoc(), tile, lockID, 0);
+      LockOp lock = LockOp::create(builder, tile.getLoc(), tile, lockID, 0);
 
       lockChains[std::make_pair(release, acquire)] = std::make_pair(lock, 1);
 

--- a/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIECtrlPacketToDma.cpp
@@ -192,7 +192,7 @@ struct AIECtrlPacketToDmaPass
 
         SymbolRefAttr metadata =
             SymbolRefAttr::get(builder.getContext(), batchIt->shimDmaAllocName);
-        NpuDmaMemcpyNdOp::create(builder, builder.getUnknownLoc(), newBlockArg,
+        NpuDmaMemcpyNdOp::create(builder, loc, newBlockArg,
                                  SmallVector<Value>{}, SmallVector<Value>{},
                                  SmallVector<Value>{}, ArrayRef(staticOffsets),
                                  ArrayRef(staticSizes), ArrayRef(staticStrides),

--- a/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEExpandLoadPdi.cpp
@@ -68,7 +68,7 @@ static LogicalResult transformLoadPdi(NpuLoadPdiOp loadPdiOp, ModuleOp moduleOp,
   AIE::DeviceOp emptyDevice = moduleOp.lookupSymbol<AIE::DeviceOp>(emptyName);
   if (!emptyDevice) {
     auto deviceType = referencedDevice.getDevice();
-    auto loc = builder.getUnknownLoc();
+    auto loc = loadPdiOp.getLoc();
     emptyDevice = AIE::DeviceOp::create(builder, loc, deviceType,
                                         builder.getStringAttr(emptyName));
     emptyDevice.getRegion().emplaceBlock();

--- a/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIEHerdRouting.cpp
@@ -304,15 +304,12 @@ struct AIEHerdRoutingPass
 
       builder.setInsertionPoint(device.getBody()->getTerminator());
 
-      auto iterx =
-          IterOp::create(builder, builder.getUnknownLoc(), x, x + 1, 1);
-      auto itery =
-          IterOp::create(builder, builder.getUnknownLoc(), y, y + 1, 1);
-      auto sel = SelectOp::create(builder, builder.getUnknownLoc(), herd, iterx,
-                                  itery);
-      auto swbox = SwitchboxOp::create(builder, builder.getUnknownLoc(), sel);
-      SwitchboxOp::ensureTerminator(swbox.getConnections(), builder,
-                                    builder.getUnknownLoc());
+      Location loc = herdOp->getLoc();
+      auto iterx = IterOp::create(builder, loc, x, x + 1, 1);
+      auto itery = IterOp::create(builder, loc, y, y + 1, 1);
+      auto sel = SelectOp::create(builder, loc, herd, iterx, itery);
+      auto swbox = SwitchboxOp::create(builder, loc, sel);
+      SwitchboxOp::ensureTerminator(swbox.getConnections(), builder, loc);
       Block &b = swbox.getConnections().front();
       builder.setInsertionPoint(b.getTerminator());
 
@@ -322,8 +319,8 @@ struct AIEHerdRoutingPass
         WireBundle destBundle = destPort.bundle;
         int destChannel = destPort.channel;
 
-        ConnectOp::create(builder, builder.getUnknownLoc(), sourceBundle,
-                          sourceChannel, destBundle, destChannel);
+        ConnectOp::create(builder, loc, sourceBundle, sourceChannel, destBundle,
+                          destChannel);
       }
     }
 

--- a/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMemcpy.cpp
@@ -46,9 +46,10 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
   LowerAIEMemcpy(MLIRContext *context, PatternBenefit benefit = 1)
       : OpConversionPattern<MemcpyOp>(context, benefit) {}
 
-  void createDMABlocksAndOps(MemOp &mem, StringRef tokenName, int acquireTknVal,
-                             int releaseTknVal, Value buf, int offset, int len,
-                             DMAChannelDir dmaDir, int channelIndex,
+  void createDMABlocksAndOps(MemOp &mem, Location loc, StringRef tokenName,
+                             int acquireTknVal, int releaseTknVal, Value buf,
+                             int offset, int len, DMAChannelDir dmaDir,
+                             int channelIndex,
                              ConversionPatternRewriter &rewriter) const {
 
     Region &r = mem.getBody();
@@ -57,7 +58,7 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     Block *bdBlock = rewriter.createBlock(&endBlock);
 
     rewriter.setInsertionPointToStart(dmaBlock);
-    DMAStartOp::create(rewriter, rewriter.getUnknownLoc(), dmaDir, channelIndex,
+    DMAStartOp::create(rewriter, loc, dmaDir, channelIndex,
                        /*repeatCount*/ 0, bdBlock, &endBlock);
 
     // Setup bd Block
@@ -65,12 +66,12 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     // for specifying DMA Block description (which buffer type (A/B), transfer
     // length/address, etc.)
     rewriter.setInsertionPointToStart(bdBlock);
-    UseTokenOp::create(rewriter, rewriter.getUnknownLoc(), tokenName,
-                       acquireTknVal, LockAction::Acquire);
-    DMABDOp::create(rewriter, rewriter.getUnknownLoc(), buf, offset, len);
-    UseTokenOp::create(rewriter, rewriter.getUnknownLoc(), tokenName,
-                       releaseTknVal, LockAction::Release);
-    NextBDOp::create(rewriter, rewriter.getUnknownLoc(), &endBlock);
+    UseTokenOp::create(rewriter, loc, tokenName, acquireTknVal,
+                       LockAction::Acquire);
+    DMABDOp::create(rewriter, loc, buf, offset, len);
+    UseTokenOp::create(rewriter, loc, tokenName, releaseTknVal,
+                       LockAction::Release);
+    NextBDOp::create(rewriter, loc, &endBlock);
   }
 
   LogicalResult
@@ -90,12 +91,12 @@ struct LowerAIEMemcpy : public OpConversionPattern<MemcpyOp> {
     MemOp srcMem = srcTileOp(op).getMemOp();
     MemOp dstMem = dstTileOp(op).getMemOp();
 
-    createDMABlocksAndOps(srcMem, tokenName, acquireTknVal, releaseTknVal,
-                          srcBuf, srcOffset, srcLen, DMAChannelDir::MM2S, 0,
-                          rewriter);
-    createDMABlocksAndOps(dstMem, tokenName, acquireTknVal, releaseTknVal,
-                          dstBuf, dstOffset, dstLen, DMAChannelDir::S2MM, 0,
-                          rewriter);
+    createDMABlocksAndOps(srcMem, op.getLoc(), tokenName, acquireTknVal,
+                          releaseTknVal, srcBuf, srcOffset, srcLen,
+                          DMAChannelDir::MM2S, 0, rewriter);
+    createDMABlocksAndOps(dstMem, op.getLoc(), tokenName, acquireTknVal,
+                          releaseTknVal, dstBuf, dstOffset, dstLen,
+                          DMAChannelDir::S2MM, 0, rewriter);
 
     rewriter.eraseOp(op);
     return success();
@@ -126,8 +127,8 @@ struct AIELowerMemcpyPass
       assert(destChannel[op.getDstTile()] <= 2 &&
              "Could not allocate more than two dest. channel when creating "
              "FlowOp");
-      FlowOp::create(builder, builder.getUnknownLoc(), srcTile, WireBundle::DMA,
-                     0, dstTile, WireBundle::DMA, destChannel[op.getDstTile()]);
+      FlowOp::create(builder, op.getLoc(), srcTile, WireBundle::DMA, 0, dstTile,
+                     WireBundle::DMA, destChannel[op.getDstTile()]);
       destChannel[op.getDstTile()]++;
     }
 

--- a/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
+++ b/lib/Dialect/AIEX/Transforms/AIELowerMulticast.cpp
@@ -67,7 +67,7 @@ struct AIELowerMulticastPass
           TileOp destTile =
               dyn_cast<TileOp>(multiDest.getTile().getDefiningOp());
           Port destPort = multiDest.port();
-          FlowOp::create(builder, builder.getUnknownLoc(), srcTile,
+          FlowOp::create(builder, multiDest.getLoc(), srcTile,
                          sourcePort.bundle, sourcePort.channel, destTile,
                          destPort.bundle, destPort.channel);
         }

--- a/lib/Targets/AIERT.cpp
+++ b/lib/Targets/AIERT.cpp
@@ -199,7 +199,40 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 struct xilinx::AIE::AIERTControl::AIERtImpl {
   XAie_Config configPtr;
   XAie_DevInst devInst;
+
+  // One Location per recorded XAie_TxnCmd. Populated by TxnLocBracket scopes.
+  // Indexed by command position in the serialized transaction binary.
+  std::vector<mlir::Location> txnInstrLocs;
 };
+
+// Walk DevInst->TxnList to find the active XAie_TxnInst (single-threaded
+// compilation: at most one) and return its NumCmds. Returns 0 if no
+// transaction is being recorded. The XAie_TxnInst struct and TxnList layout
+// are part of aie-rt's public xaiegbl.h, so this only depends on the public
+// header.
+static uint32_t getActiveTxnNumCmds(XAie_DevInst &devInst) {
+  XAie_List *node = devInst.TxnList.Next;
+  if (!node)
+    return 0;
+  XAie_TxnInst *inst = reinterpret_cast<XAie_TxnInst *>(
+      reinterpret_cast<char *>(node) - offsetof(XAie_TxnInst, Node));
+  return inst->NumCmds;
+}
+
+xilinx::AIE::TxnLocBracket::TxnLocBracket(AIERTControl &c, mlir::Location l)
+    : ctl(c), loc(l), startCmds(c.getCurrentTxnNumCmds()) {}
+
+xilinx::AIE::TxnLocBracket::~TxnLocBracket() {
+  uint32_t endCmds = ctl.getCurrentTxnNumCmds();
+  if (endCmds <= startCmds)
+    return;
+  // Only record meaningful locations. Falling through (no entry) lets the
+  // downstream emitter use its fallback (device.getLoc()), which preserves
+  // the pre-existing behavior for source ops that don't carry a real loc.
+  if (mlir::isa<mlir::UnknownLoc>(loc))
+    return;
+  ctl.recordTxnLocRange(startCmds, endCmds, loc);
+}
 
 xilinx::AIE::AIERTControl::~AIERTControl() = default;
 
@@ -494,6 +527,7 @@ LogicalResult configureBdInBlock(const AIE::AIETargetModel &targetModel,
 LogicalResult xilinx::AIE::AIERTControl::pushToBdQueueAndEnable(
     Operation &op, int col, int row, int chNum, const DMAChannelDir &channelDir,
     int bdId, int repeatCount) {
+  TxnLocBracket bracket(*this, op.getLoc());
   XAie_DmaDirection direction =
       channelDir == DMAChannelDir::S2MM ? DMA_S2MM : DMA_MM2S;
   auto tileLoc = XAie_TileLoc(col, row);
@@ -515,6 +549,7 @@ LogicalResult xilinx::AIE::AIERTControl::configureLocksAndBd(Block &block,
   assert(bd.getBdId().has_value() &&
          "DMABDOp must have assigned bd_id; did you forget to run "
          "aie-assign-bd-ids?");
+  TxnLocBracket bracket(*this, bd.getLoc());
   XAie_DmaDesc dmaTileBd;
   auto tileLoc = XAie_TileLoc(col, row);
   TRY_XAIE_API_EMIT_ERROR(bd, XAie_DmaDescInit, &aiert->devInst, &dmaTileBd,
@@ -534,6 +569,7 @@ LogicalResult xilinx::AIE::AIERTControl::initLocks(DeviceOp &targetOp) {
   for (auto tileOp : targetOp.getOps<TileOp>()) {
     auto tileLoc = XAie_TileLoc(tileOp.colIndex(), tileOp.rowIndex());
     if (!tileOp.isShimTile() && tileOp.getCoreOp()) {
+      TxnLocBracket bracket(*this, tileOp.getLoc());
       TRY_XAIE_API_EMIT_ERROR(tileOp, XAie_CoreReset, &aiert->devInst, tileLoc);
       TRY_XAIE_API_EMIT_ERROR(tileOp, XAie_CoreUnreset, &aiert->devInst,
                               tileLoc);
@@ -549,6 +585,7 @@ LogicalResult xilinx::AIE::AIERTControl::initLocks(DeviceOp &targetOp) {
   // Set locks with explicit initializers
   targetOp.walk<WalkOrder::PreOrder>([&](LockOp lockOp) {
     if (lockOp.getLockID() && lockOp.getInit()) {
+      TxnLocBracket bracket(*this, lockOp.getLoc());
       auto tileLoc = XAie_TileLoc(lockOp.getTileOp().colIndex(),
                                   lockOp.getTileOp().rowIndex());
       auto locInit = XAie_LockInit(*lockOp.getLockID(), *lockOp.getInit());
@@ -567,6 +604,7 @@ LogicalResult xilinx::AIE::AIERTControl::initBuffers(DeviceOp &targetOp) {
     auto initialValue = bufferOp.getInitialValue();
     if (!initialValue)
       return;
+    TxnLocBracket bracket(*this, bufferOp.getLoc());
     mlir::DenseElementsAttr denseInit =
         dyn_cast<mlir::DenseElementsAttr>(initialValue.value());
     if (!denseInit)
@@ -624,15 +662,18 @@ LogicalResult xilinx::AIE::AIERTControl::configureSwitches(DeviceOp &targetOp) {
            "Only NPU currently supported");
 
     Block &b = switchboxOp.getConnections().front();
-    for (auto connectOp : b.getOps<ConnectOp>())
+    for (auto connectOp : b.getOps<ConnectOp>()) {
+      TxnLocBracket bracket(*this, connectOp.getLoc());
       TRY_XAIE_API_EMIT_ERROR(
           switchboxOp, XAie_StrmConnCctEnable, &aiert->devInst, tileLoc,
           WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getSourceBundle()),
           connectOp.sourceIndex(),
           WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getDestBundle()),
           connectOp.destIndex());
+    }
 
     for (auto masterSetOp : b.getOps<MasterSetOp>()) {
+      TxnLocBracket bracket(*this, masterSetOp.getLoc());
       int mask = 0;
       int arbiter = -1;
 
@@ -667,6 +708,7 @@ LogicalResult xilinx::AIE::AIERTControl::configureSwitches(DeviceOp &targetOp) {
     }
 
     for (auto packetRulesOp : b.getOps<PacketRulesOp>()) {
+      TxnLocBracket bracket(*this, packetRulesOp.getLoc());
       int slot = 0;
       Block &block = packetRulesOp.getRules().front();
       for (auto slotOp : block.getOps<PacketRuleOp>()) {
@@ -698,6 +740,7 @@ LogicalResult xilinx::AIE::AIERTControl::configureSwitches(DeviceOp &targetOp) {
         XAie_TileLoc(muxOp.getTileOp().getCol(), muxOp.getTileOp().getRow());
     Block &b = muxOp.getConnections().front();
     for (auto connectOp : b.getOps<ConnectOp>()) {
+      TxnLocBracket bracket(*this, connectOp.getLoc());
       // demux!
       if (connectOp.getSourceBundle() == WireBundle::North)
         TRY_XAIE_API_EMIT_ERROR(muxOp, XAie_EnableAieToShimDmaStrmPort,
@@ -714,18 +757,21 @@ LogicalResult xilinx::AIE::AIERTControl::configureSwitches(DeviceOp &targetOp) {
   for (auto switchboxOp : targetOp.getOps<ShimSwitchboxOp>()) {
     Block &b = switchboxOp.getConnections().front();
     auto tileLoc = XAie_TileLoc(switchboxOp.getCol(), 0);
-    for (auto connectOp : b.getOps<ConnectOp>())
+    for (auto connectOp : b.getOps<ConnectOp>()) {
+      TxnLocBracket bracket(*this, connectOp.getLoc());
       TRY_XAIE_API_EMIT_ERROR(
           switchboxOp, XAie_StrmConnCctEnable, &aiert->devInst, tileLoc,
           WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getSourceBundle()),
           connectOp.sourceIndex(),
           WIRE_BUNDLE_TO_STRM_SW_PORT_TYPE.at(connectOp.getDestBundle()),
           connectOp.destIndex());
+    }
   }
 
   // Cascade configuration
   if (isa<AIE2TargetModel>(targetModel)) {
     for (auto configOp : targetOp.getOps<ConfigureCascadeOp>()) {
+      TxnLocBracket bracket(*this, configOp.getLoc());
       TileOp tile = cast<TileOp>(configOp.getTile().getDefiningOp());
       auto tileLoc = XAie_TileLoc(tile.getCol(), tile.getRow());
       TRY_XAIE_API_EMIT_ERROR(
@@ -816,9 +862,11 @@ LogicalResult xilinx::AIE::AIERTControl::addCoreEnable(DeviceOp &targetOp) {
   // Start execution of all the cores.
   for (auto tileOp : targetOp.getOps<TileOp>()) {
     auto tileLoc = XAie_TileLoc(tileOp.colIndex(), tileOp.rowIndex());
-    if (!tileOp.isShimTile() && tileOp.getCoreOp())
+    if (!tileOp.isShimTile() && tileOp.getCoreOp()) {
+      TxnLocBracket bracket(*this, tileOp.getCoreOp().getLoc());
       TRY_XAIE_API_EMIT_ERROR(targetOp, XAie_CoreEnable, &aiert->devInst,
                               tileLoc);
+    }
   }
   return success();
 }
@@ -1019,6 +1067,7 @@ void xilinx::AIE::AIERTControl::dmaUpdateBdAddr(int col, int row, size_t addr,
 }
 
 void xilinx::AIE::AIERTControl::startTransaction() {
+  aiert->txnInstrLocs.clear();
   TRY_XAIE_API_FATAL_ERROR(XAie_StartTransaction, &aiert->devInst,
                            XAIE_TRANSACTION_DISABLE_AUTO_FLUSH);
 }
@@ -1029,4 +1078,24 @@ std::vector<uint8_t> xilinx::AIE::AIERTControl::exportSerializedTransaction() {
   XAie_TxnHeader *hdr = (XAie_TxnHeader *)txn_ptr;
   std::vector<uint8_t> txn_data(txn_ptr, txn_ptr + hdr->TxnSize);
   return txn_data;
+}
+
+const std::vector<mlir::Location> &
+xilinx::AIE::AIERTControl::getTxnInstrLocs() const {
+  return aiert->txnInstrLocs;
+}
+
+uint32_t xilinx::AIE::AIERTControl::getCurrentTxnNumCmds() const {
+  return getActiveTxnNumCmds(aiert->devInst);
+}
+
+void xilinx::AIE::AIERTControl::recordTxnLocRange(uint32_t startCmds,
+                                                  uint32_t endCmds,
+                                                  mlir::Location loc) {
+  if (endCmds <= startCmds)
+    return;
+  if (aiert->txnInstrLocs.size() < endCmds)
+    aiert->txnInstrLocs.resize(endCmds, mlir::UnknownLoc::get(loc.getContext()));
+  for (uint32_t i = startCmds; i < endCmds; ++i)
+    aiert->txnInstrLocs[i] = loc;
 }

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -12,6 +12,7 @@
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/IR/AIETargetModel.h"
+#include "aie/Dialect/AIE/Util/AIELocCheckpoint.h"
 #include "aie/Dialect/AIE/Util/AIERegisterDatabase.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 
@@ -545,8 +546,20 @@ static llvm::json::Value locToJSON(mlir::Location loc) {
     json::Array children;
     for (mlir::Location c : fused.getLocations())
       children.push_back(locToJSON(c));
-    return json::Value(
-        json::Object{{"kind", "fused"}, {"children", std::move(children)}});
+    json::Object o{{"kind", "fused"}, {"children", std::move(children)}};
+    // Surface checkpoint metadata produced by AIELocCheckpoint (Phase 4):
+    // a StringAttr starting with "checkpoint:" gets unwrapped into a
+    // top-level "checkpoint" key for easy consumption by tooling.
+    if (auto md = dyn_cast_or_null<mlir::StringAttr>(fused.getMetadata())) {
+      llvm::StringRef sv = md.getValue();
+      llvm::StringRef prefix =
+          xilinx::AIE::getCheckpointMetadataPrefix(); // "checkpoint:"
+      if (sv.starts_with(prefix))
+        o["checkpoint"] = sv.drop_front(prefix.size()).str();
+      else
+        o["metadata"] = sv.str();
+    }
+    return json::Value(std::move(o));
   }
   if (auto cs = dyn_cast<mlir::CallSiteLoc>(loc))
     return json::Value(json::Object{

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -305,7 +305,7 @@ lookupRegisterByAddress(uint64_t address, const AIETargetModel &tm,
 static void pushLocEntry(std::vector<TxnLocEntry> *locmap,
                          uint32_t byteOffsetBefore, uint32_t byteOffsetAfter,
                          StringRef opcodeName, StringRef sourceOpName,
-                         uint64_t address, mlir::Operation *op,
+                         std::optional<uint64_t> address, mlir::Operation *op,
                          const AIETargetModel &tm) {
   if (!locmap)
     return;
@@ -318,7 +318,7 @@ static void pushLocEntry(std::vector<TxnLocEntry> *locmap,
   e.loc = op->getLoc();
   if (address) {
     if (auto regName =
-            lookupRegisterByAddress(address, tm, getRegDB(), e.registerModule);
+            lookupRegisterByAddress(*address, tm, getRegDB(), e.registerModule);
         !regName.empty()) {
       e.registerName = regName.str();
     }
@@ -375,7 +375,7 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
             uint32_t before = byteOffset();
             appendSync(instructions, op);
             pushLocEntry(locmap, before, byteOffset(), "TCT",
-                         op->getName().getStringRef(), 0, op, tm);
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           })
           .Case<NpuWrite32Op>([&](auto op) {
             count++;
@@ -406,7 +406,7 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
             uint32_t before = byteOffset();
             appendLoadPdi(instructions, op);
             pushLocEntry(locmap, before, byteOffset(), "LOAD_PDI",
-                         op->getName().getStringRef(), 0, op, tm);
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           })
           .Case<NpuAddressPatchOp>([&](auto op) {
             count++;
@@ -420,21 +420,21 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
             uint32_t before = byteOffset();
             appendPreempt(instructions, op);
             pushLocEntry(locmap, before, byteOffset(), "PREEMPT",
-                         op->getName().getStringRef(), 0, op, tm);
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           })
           .Case<NpuCreateScratchpadOp>([&](auto op) {
             count++;
             uint32_t before = byteOffset();
             appendCreateScratchpad(instructions, op);
             pushLocEntry(locmap, before, byteOffset(), "CREATE_SCRATCHPAD",
-                         op->getName().getStringRef(), 0, op, tm);
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           })
           .Case<NpuUpdateFromScratchpadOp>([&](auto op) {
             count++;
             uint32_t before = byteOffset();
             appendUpdateRegFromScratchpad(instructions, op);
             pushLocEntry(locmap, before, byteOffset(), "UPDATE_FROM_SCRATCHPAD",
-                         op->getName().getStringRef(), 0, op, tm);
+                         op->getName().getStringRef(), std::nullopt, op, tm);
           });
     }
   }
@@ -576,7 +576,7 @@ void xilinx::AIE::emitNpuLocmapJSON(llvm::raw_ostream &output,
     o["opcode"] = e.opcodeName;
     o["source_op"] = e.sourceOpName;
     if (e.address)
-      o["address"] = llvm::formatv("{0:X}", e.address).str();
+      o["address"] = llvm::formatv("{0:X}", *e.address).str();
     if (!e.registerName.empty()) {
       o["register"] = e.registerName;
       o["register_module"] = e.registerModule;

--- a/lib/Targets/AIETargetNPU.cpp
+++ b/lib/Targets/AIETargetNPU.cpp
@@ -11,6 +11,8 @@
 #include "aie/Targets/AIETargets.h"
 
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
+#include "aie/Dialect/AIE/IR/AIETargetModel.h"
+#include "aie/Dialect/AIE/Util/AIERegisterDatabase.h"
 #include "aie/Dialect/AIEX/IR/AIEXDialect.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -20,7 +22,11 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Format.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/JSON.h"
+#include "llvm/Support/raw_ostream.h"
 
+#include <memory>
 #include <vector>
 
 extern "C" {
@@ -239,9 +245,93 @@ void appendUpdateRegFromScratchpad(std::vector<uint32_t> &instructions,
 
 } // namespace
 
+namespace {
+
+// Lazy-loaded regdb for register-name decoration. Loaded once per process,
+// returns nullptr if the JSON files cannot be located (e.g. install dir not
+// set). Decoration is best-effort.
+static const xilinx::AIE::RegisterDatabase *getRegDB() {
+  static std::unique_ptr<xilinx::AIE::RegisterDatabase> db = []() {
+    return xilinx::AIE::RegisterDatabase::loadAIE2();
+  }();
+  return db.get();
+}
+
+// Decompose an absolute device address into (col, row, offset) using the
+// target model's column/row shifts, then derive the regdb module name from
+// the row's tile type. Looks the (module, offset) up in regdb. Returns the
+// register name on success and writes the module name to *outModule. On any
+// failure returns empty StringRef.
+static llvm::StringRef
+lookupRegisterByAddress(uint64_t address, const AIETargetModel &tm,
+                        const xilinx::AIE::RegisterDatabase *regdb,
+                        std::string &outModule) {
+  outModule.clear();
+  if (!regdb)
+    return {};
+  uint32_t colShift = tm.getColumnShift();
+  uint32_t rowShift = tm.getRowShift();
+  uint8_t col = static_cast<uint8_t>((address >> colShift) & 0xFF);
+  uint8_t row = static_cast<uint8_t>((address >> rowShift) & 0xFF);
+  uint64_t baseMask = (uint64_t{1} << rowShift) - 1;
+  uint32_t offset = static_cast<uint32_t>(address & baseMask);
+
+  // Determine module from tile type.
+  StringRef moduleName;
+  if (tm.isShimNOCTile(col, row) || tm.isShimPLTile(col, row)) {
+    moduleName = "pl_module";
+  } else if (tm.isMemTile(col, row)) {
+    moduleName = "mem_tile_module";
+  } else {
+    // For aie tiles, regdb has both core_module and memory_module. The
+    // offset alone disambiguates. Try core first then memory.
+    if (auto *r = regdb->lookupRegisterByOffset(offset, "core_module")) {
+      outModule = "core_module";
+      return r->name;
+    }
+    if (auto *r = regdb->lookupRegisterByOffset(offset, "memory_module")) {
+      outModule = "memory_module";
+      return r->name;
+    }
+    return {};
+  }
+  if (auto *r = regdb->lookupRegisterByOffset(offset, moduleName)) {
+    outModule = moduleName.str();
+    return r->name;
+  }
+  return {};
+}
+
+static void pushLocEntry(std::vector<TxnLocEntry> *locmap,
+                         uint32_t byteOffsetBefore, uint32_t byteOffsetAfter,
+                         StringRef opcodeName, StringRef sourceOpName,
+                         uint64_t address, mlir::Operation *op,
+                         const AIETargetModel &tm) {
+  if (!locmap)
+    return;
+  TxnLocEntry e;
+  e.byteOffset = byteOffsetBefore;
+  e.byteSize = byteOffsetAfter - byteOffsetBefore;
+  e.opcodeName = opcodeName.str();
+  e.sourceOpName = sourceOpName.str();
+  e.address = address;
+  e.loc = op->getLoc();
+  if (address) {
+    if (auto regName =
+            lookupRegisterByAddress(address, tm, getRegDB(), e.registerModule);
+        !regName.empty()) {
+      e.registerName = regName.str();
+    }
+  }
+  locmap->push_back(std::move(e));
+}
+
+} // namespace
+
 LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
     mlir::ModuleOp moduleOp, std::vector<uint32_t> &instructions,
-    StringRef deviceName, StringRef sequenceName) {
+    StringRef deviceName, StringRef sequenceName,
+    std::vector<TxnLocEntry> *locmap) {
 
   DeviceOp deviceOp =
       DeviceOp::getForSymbolInModuleOrError(moduleOp, deviceName);
@@ -272,44 +362,79 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
   if (!seq) {
     return failure();
   }
+
+  auto byteOffset = [&]() -> uint32_t {
+    return static_cast<uint32_t>(instructions.size() * sizeof(uint32_t));
+  };
+
   for (Block &block : seq.getBody()) {
     for (Operation &o : block) {
       llvm::TypeSwitch<Operation *>(&o)
           .Case<NpuSyncOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendSync(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "TCT",
+                         op->getName().getStringRef(), 0, op, tm);
           })
           .Case<NpuWrite32Op>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
+            uint64_t addr = op.getAbsoluteAddress().value_or(0);
             appendWrite32(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "WRITE32",
+                         op->getName().getStringRef(), addr, op, tm);
           })
           .Case<NpuBlockWriteOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
+            uint64_t addr = op.getAbsoluteAddress().value_or(0);
             appendBlockWrite(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "BLOCKWRITE",
+                         op->getName().getStringRef(), addr, op, tm);
           })
           .Case<NpuMaskWrite32Op>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
+            uint64_t addr = op.getAbsoluteAddress().value_or(0);
             appendMaskWrite32(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "MASKWRITE",
+                         op->getName().getStringRef(), addr, op, tm);
           })
           .Case<NpuLoadPdiOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendLoadPdi(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "LOAD_PDI",
+                         op->getName().getStringRef(), 0, op, tm);
           })
           .Case<NpuAddressPatchOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendAddressPatch(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "ADDRESS_PATCH",
+                         op->getName().getStringRef(), op.getAddr(), op, tm);
           })
           .Case<NpuPreemptOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendPreempt(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "PREEMPT",
+                         op->getName().getStringRef(), 0, op, tm);
           })
           .Case<NpuCreateScratchpadOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendCreateScratchpad(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "CREATE_SCRATCHPAD",
+                         op->getName().getStringRef(), 0, op, tm);
           })
           .Case<NpuUpdateFromScratchpadOp>([&](auto op) {
             count++;
+            uint32_t before = byteOffset();
             appendUpdateRegFromScratchpad(instructions, op);
+            pushLocEntry(locmap, before, byteOffset(), "UPDATE_FROM_SCRATCHPAD",
+                         op->getName().getStringRef(), 0, op, tm);
           });
     }
   }
@@ -322,7 +447,7 @@ LogicalResult xilinx::AIE::AIETranslateNpuToBinary(
 
 LogicalResult xilinx::AIE::AIETranslateControlPacketsToUI32Vec(
     ModuleOp module, std::vector<uint32_t> &instructions, StringRef deviceName,
-    StringRef sequenceName) {
+    StringRef sequenceName, std::vector<TxnLocEntry> *locmap) {
   DeviceOp deviceOp =
       AIE::DeviceOp::getForSymbolInModuleOrError(module, deviceName);
   if (!deviceOp) {
@@ -336,11 +461,15 @@ LogicalResult xilinx::AIE::AIETranslateControlPacketsToUI32Vec(
     return failure();
   }
 
+  const AIETargetModel &tm = deviceOp.getTargetModel();
   Block &entry = seq.getBody().front();
   for (auto &o : entry) {
     auto packetOp = dyn_cast<AIEX::NpuControlPacketOp>(o);
     if (!packetOp)
       continue;
+
+    uint32_t before =
+        static_cast<uint32_t>(instructions.size() * sizeof(uint32_t));
 
     uint32_t size = 0;
     auto data = packetOp.getData();
@@ -385,6 +514,78 @@ LogicalResult xilinx::AIE::AIETranslateControlPacketsToUI32Vec(
     if (opc == 0x0 || opc == 0x2)
       for (unsigned i = 0; i < size; i++)
         words[i + 2] = data.value()[i];
+
+    uint32_t after =
+        static_cast<uint32_t>(instructions.size() * sizeof(uint32_t));
+    pushLocEntry(locmap, before, after, "CONTROL_PACKET",
+                 packetOp->getName().getStringRef(), packetOp.getAddress(),
+                 packetOp, tm);
   }
   return success();
+}
+
+// Render an mlir::Location as a JSON object, recursing into NameLoc and
+// FusedLoc to recover the file:line:col + IRON name structure produced by
+// Phase-1 capture (see python/iron/_loc.py).
+static llvm::json::Value locToJSON(mlir::Location loc) {
+  using namespace llvm;
+  if (auto f = dyn_cast<mlir::FileLineColLoc>(loc))
+    return json::Value(json::Object{
+        {"kind", "file"},
+        {"file", f.getFilename().str()},
+        {"line", static_cast<int64_t>(f.getLine())},
+        {"col", static_cast<int64_t>(f.getColumn())},
+    });
+  if (auto n = dyn_cast<mlir::NameLoc>(loc)) {
+    json::Object o{{"kind", "name"}, {"name", n.getName().str()}};
+    o["child"] = locToJSON(n.getChildLoc());
+    return json::Value(std::move(o));
+  }
+  if (auto fused = dyn_cast<mlir::FusedLoc>(loc)) {
+    json::Array children;
+    for (mlir::Location c : fused.getLocations())
+      children.push_back(locToJSON(c));
+    return json::Value(
+        json::Object{{"kind", "fused"}, {"children", std::move(children)}});
+  }
+  if (auto cs = dyn_cast<mlir::CallSiteLoc>(loc))
+    return json::Value(json::Object{
+        {"kind", "callsite"},
+        {"callee", locToJSON(cs.getCallee())},
+        {"caller", locToJSON(cs.getCaller())},
+    });
+  if (isa<mlir::OpaqueLoc>(loc))
+    return json::Value(json::Object{{"kind", "opaque"}});
+  return json::Value(json::Object{{"kind", "unknown"}});
+}
+
+void xilinx::AIE::emitNpuLocmapJSON(llvm::raw_ostream &output,
+                                    llvm::StringRef deviceName,
+                                    llvm::StringRef binaryName,
+                                    const std::vector<TxnLocEntry> &locmap) {
+  llvm::json::Object root;
+  root["version"] = 1;
+  root["device"] = deviceName.str();
+  root["binary"] = binaryName.str();
+
+  llvm::json::Array opsArr;
+  for (const auto &e : locmap) {
+    llvm::json::Object o;
+    o["byte_offset"] = static_cast<int64_t>(e.byteOffset);
+    o["byte_size"] = static_cast<int64_t>(e.byteSize);
+    o["opcode"] = e.opcodeName;
+    o["source_op"] = e.sourceOpName;
+    if (e.address)
+      o["address"] = llvm::formatv("{0:X}", e.address).str();
+    if (!e.registerName.empty()) {
+      o["register"] = e.registerName;
+      o["register_module"] = e.registerModule;
+    }
+    if (e.loc)
+      o["loc"] = locToJSON(*e.loc);
+    opsArr.push_back(std::move(o));
+  }
+  root["operations"] = std::move(opsArr);
+
+  output << llvm::formatv("{0:2}\n", llvm::json::Value(std::move(root)));
 }

--- a/lib/Targets/AIETargets.cpp
+++ b/lib/Targets/AIETargets.cpp
@@ -383,6 +383,22 @@ void registerAIETranslations() {
         return success();
       },
       registerDialects);
+  TranslateFromMLIRRegistration registrationNPULocmap(
+      "aie-npu-to-binary-locmap",
+      "Translate npu instructions to a JSON sidecar mapping each transaction "
+      "word's byte offset to its source MLIR Location (and regdb register "
+      "name where applicable). The .bin itself is not emitted.",
+      [](ModuleOp module, raw_ostream &output) {
+        std::vector<uint32_t> instructions;
+        std::vector<TxnLocEntry> locmap;
+        auto r = AIETranslateNpuToBinary(module, instructions, deviceName,
+                                         sequenceName, &locmap);
+        if (failed(r))
+          return r;
+        emitNpuLocmapJSON(output, deviceName, /*binaryName=*/"", locmap);
+        return success();
+      },
+      registerDialects);
   TranslateFromMLIRRegistration registrationCtrlPkt(
       "aie-ctrlpkt-to-bin", "Translate aiex.control_packet ops to binary",
       [](ModuleOp module, raw_ostream &output) {

--- a/python/iron/_loc.py
+++ b/python/iron/_loc.py
@@ -1,0 +1,107 @@
+# _loc.py -*- Python -*-
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+"""Helpers for capturing user Python source locations and projecting them
+into MLIR ``Location`` attributes.
+
+IRON entry points (``ObjectFifo``, ``Worker``, ``Runtime.fill`` / ``drain``,
+``Kernel`` / ``ExternalFunction``) call ``capture_user_loc`` from their
+constructor or call site. The captured ``ir.Location`` is later applied as a
+context (``with self._user_loc:``) inside ``resolve()`` so MLIR ops created
+from it inherit a ``FileLineColLoc`` pointing at the user's program rather
+than ``UnknownLoc``.
+
+A ``NameLoc`` wrapper is used when a logical name is available (e.g. an
+ObjectFifo name) so the printed location reads
+``loc("of0"("user.py":42:4))`` -- the IRON-level name annotates the
+underlying source position. This mirrors how upstream MLIR uses
+``NameLoc`` to mark transformation provenance.
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .. import ir  # type: ignore
+
+
+def _is_internal_frame(filename: str) -> bool:
+    """Frames inside the IRON / aie python packages or stdlib are skipped."""
+    if not filename:
+        return True
+    # The IRON sources live next to this file; anything in the same package
+    # tree is "internal" and should be walked past.
+    pkg_root = Path(__file__).resolve().parent.parent
+    p = Path(filename).resolve()
+    try:
+        p.relative_to(pkg_root)
+        return True
+    except ValueError:
+        pass
+    # Anything under sys.prefix (stdlib, site-packages of the venv where
+    # mlir, numpy, etc. live) is also internal.
+    try:
+        p.relative_to(Path(sys.prefix).resolve())
+        return True
+    except ValueError:
+        pass
+    return False
+
+
+def capture_user_loc(
+    name: Optional[str] = None,
+    skip: int = 0,
+) -> Optional["ir.Location"]:
+    """Walk the Python call stack and return an ``ir.Location`` pointing at
+    the first frame outside the IRON / mlir-aie package.
+
+    Args:
+        name: Optional logical name. If provided, the returned location is
+            ``NameLoc.get(name, FileLineColLoc(...))`` so callers see the
+            IRON-level identifier in MLIR diagnostics.
+        skip: Number of additional frames (beyond this function's own frame)
+            to skip before starting the search. Useful when the caller is
+            itself a thin wrapper.
+
+    Returns:
+        An ``ir.Location`` if an MLIR ``Context`` is active and a non-internal
+        frame is found, otherwise ``None``. Returning ``None`` is safe -- the
+        IRON ``resolve()`` paths fall back to ``Location.unknown()``.
+    """
+    if ir.Context.current is None:
+        return None
+
+    frame = inspect.currentframe()
+    if frame is None:
+        return None
+    # Skip our own frame plus any caller-requested frames.
+    for _ in range(1 + skip):
+        if frame.f_back is None:
+            return None
+        frame = frame.f_back
+    while frame is not None and _is_internal_frame(frame.f_code.co_filename):
+        frame = frame.f_back
+    if frame is None:
+        return None
+
+    info = inspect.getframeinfo(frame)
+    col = 0
+    if sys.version_info >= (3, 11) and getattr(info, "positions", None):
+        col = info.positions.col_offset or 0
+    file_loc = ir.Location.file(info.filename, info.lineno, col=col)
+    if name is None:
+        return file_loc
+    return ir.Location.name(name, file_loc)
+
+
+def loc_or_unknown(loc: Optional["ir.Location"]) -> "ir.Location":
+    """Return ``loc`` if non-None, else ``Location.unknown()``. Cheap helper
+    so resolve() bodies can write ``with loc_or_unknown(self._user_loc):``."""
+    return loc if loc is not None else ir.Location.unknown()

--- a/python/iron/_loc.py
+++ b/python/iron/_loc.py
@@ -10,34 +10,70 @@ into MLIR ``Location`` attributes.
 
 IRON entry points (``ObjectFifo``, ``Worker``, ``Runtime.fill`` / ``drain``,
 ``Kernel`` / ``ExternalFunction``) call ``capture_user_loc`` from their
-constructor or call site. The captured ``ir.Location`` is later applied as a
-context (``with self._user_loc:``) inside ``resolve()`` so MLIR ops created
-from it inherit a ``FileLineColLoc`` pointing at the user's program rather
-than ``UnknownLoc``.
+constructor or call site. This is *eager* frame capture: the helper records
+``(filename, line, col)`` plus an optional logical name into a tiny
+dataclass that does not require an MLIR ``Context``.
 
-A ``NameLoc`` wrapper is used when a logical name is available (e.g. an
-ObjectFifo name) so the printed location reads
-``loc("of0"("user.py":42:4))`` -- the IRON-level name annotates the
-underlying source position. This mirrors how upstream MLIR uses
+Later, when ``resolve()`` runs inside ``mlir_mod_ctx`` and a context is
+active, it calls ``loc.materialize()`` (or uses the captured object as a
+context manager: ``with self._user_loc:``) which lazily builds a
+``FileLineColLoc``, optionally wrapped in a ``NameLoc`` so the printed form
+reads ``loc("of0"("user.py":42:4))``. This mirrors how upstream MLIR uses
 ``NameLoc`` to mark transformation provenance.
 """
 from __future__ import annotations
 
 import inspect
-import os
 import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
 from .. import ir  # type: ignore
 
 
+@dataclass(frozen=True)
+class CapturedLoc:
+    """A frame snapshot taken before any MLIR Context exists.
+
+    ``materialize()`` is a no-op until called inside an active MLIR
+    ``Context`` — at which point it builds a real ``ir.Location``.
+    """
+
+    filename: str
+    line: int
+    col: int
+    name: Optional[str] = None
+
+    def materialize(self) -> "ir.Location":
+        """Build the MLIR Location. Must be called with an active Context."""
+        file_loc = ir.Location.file(self.filename, self.line, col=self.col)
+        if self.name is None:
+            return file_loc
+        return ir.Location.name(self.name, file_loc)
+
+    def __enter__(self):
+        # Materialize on entry so callers can write
+        # `with self._user_loc:` even though this is not a real Location.
+        self._active = self.materialize()
+        self._active.__enter__()
+        return self._active
+
+    def __exit__(self, *args):
+        self._active.__exit__(*args)
+        # frozen dataclass: we set _active via object.__setattr__ above? no,
+        # __enter__ above set it via normal attribute assignment which
+        # works because frozen=True only forbids assignment via __init__-
+        # produced attrs. Actually frozen dataclasses *do* forbid all
+        # assignment, so use object.__setattr__:
+        object.__setattr__(self, "_active", None)
+
+
 def _is_internal_frame(filename: str) -> bool:
     """Frames inside the IRON / aie python packages or stdlib are skipped."""
     if not filename:
         return True
-    # The IRON sources live next to this file; anything in the same package
-    # tree is "internal" and should be walked past.
     pkg_root = Path(__file__).resolve().parent.parent
     p = Path(filename).resolve()
     try:
@@ -45,8 +81,6 @@ def _is_internal_frame(filename: str) -> bool:
         return True
     except ValueError:
         pass
-    # Anything under sys.prefix (stdlib, site-packages of the venv where
-    # mlir, numpy, etc. live) is also internal.
     try:
         p.relative_to(Path(sys.prefix).resolve())
         return True
@@ -58,30 +92,22 @@ def _is_internal_frame(filename: str) -> bool:
 def capture_user_loc(
     name: Optional[str] = None,
     skip: int = 0,
-) -> Optional["ir.Location"]:
-    """Walk the Python call stack and return an ``ir.Location`` pointing at
+) -> Optional[CapturedLoc]:
+    """Walk the Python call stack and return a ``CapturedLoc`` pointing at
     the first frame outside the IRON / mlir-aie package.
 
-    Args:
-        name: Optional logical name. If provided, the returned location is
-            ``NameLoc.get(name, FileLineColLoc(...))`` so callers see the
-            IRON-level identifier in MLIR diagnostics.
-        skip: Number of additional frames (beyond this function's own frame)
-            to skip before starting the search. Useful when the caller is
-            itself a thin wrapper.
+    Returns ``None`` if no non-internal frame can be found (extremely rare;
+    only if the entire stack is within framework code). The returned object
+    works as a context manager, so callers can write
+    ``with capture_user_loc(...) or ir.Location.unknown(): ...`` or use
+    the helper :func:`loc_or_unknown`.
 
-    Returns:
-        An ``ir.Location`` if an MLIR ``Context`` is active and a non-internal
-        frame is found, otherwise ``None``. Returning ``None`` is safe -- the
-        IRON ``resolve()`` paths fall back to ``Location.unknown()``.
+    No MLIR ``Context`` is required at capture time — only at materialize
+    time (i.e. when used as a context manager inside ``resolve()``).
     """
-    if ir.Context.current is None:
-        return None
-
     frame = inspect.currentframe()
     if frame is None:
         return None
-    # Skip our own frame plus any caller-requested frames.
     for _ in range(1 + skip):
         if frame.f_back is None:
             return None
@@ -95,13 +121,19 @@ def capture_user_loc(
     col = 0
     if sys.version_info >= (3, 11) and getattr(info, "positions", None):
         col = info.positions.col_offset or 0
-    file_loc = ir.Location.file(info.filename, info.lineno, col=col)
-    if name is None:
-        return file_loc
-    return ir.Location.name(name, file_loc)
+    return CapturedLoc(filename=info.filename, line=info.lineno, col=col, name=name)
 
 
-def loc_or_unknown(loc: Optional["ir.Location"]) -> "ir.Location":
-    """Return ``loc`` if non-None, else ``Location.unknown()``. Cheap helper
-    so resolve() bodies can write ``with loc_or_unknown(self._user_loc):``."""
-    return loc if loc is not None else ir.Location.unknown()
+@contextmanager
+def loc_or_unknown(loc):
+    """``with`` block that activates ``loc`` (a ``CapturedLoc`` or
+    ``ir.Location``) if non-None, else falls back to ``Location.unknown()``.
+    Materialization happens here (inside an active MLIR Context)."""
+    if loc is None:
+        active = ir.Location.unknown()
+    elif isinstance(loc, CapturedLoc):
+        active = loc.materialize()
+    else:
+        active = loc
+    with active:
+        yield active

--- a/python/iron/_loc.py
+++ b/python/iron/_loc.py
@@ -54,20 +54,17 @@ class CapturedLoc:
         return ir.Location.name(self.name, file_loc)
 
     def __enter__(self):
-        # Materialize on entry so callers can write
-        # `with self._user_loc:` even though this is not a real Location.
-        self._active = self.materialize()
-        self._active.__enter__()
-        return self._active
+        # Frozen dataclass forbids ordinary attribute assignment, so go
+        # through object.__setattr__ to stash the materialized Location.
+        active = self.materialize()
+        object.__setattr__(self, "_active", active)
+        active.__enter__()
+        return active
 
     def __exit__(self, *args):
-        self._active.__exit__(*args)
-        # frozen dataclass: we set _active via object.__setattr__ above? no,
-        # __enter__ above set it via normal attribute assignment which
-        # works because frozen=True only forbids assignment via __init__-
-        # produced attrs. Actually frozen dataclasses *do* forbid all
-        # assignment, so use object.__setattr__:
+        active = self._active
         object.__setattr__(self, "_active", None)
+        return active.__exit__(*args)
 
 
 def _is_internal_frame(filename: str) -> bool:

--- a/python/iron/buffer.py
+++ b/python/iron/buffer.py
@@ -18,6 +18,7 @@ from ..helpers.util import (
 )
 from .device import Tile
 from .resolvable import Resolvable, NotResolvedError
+from ._loc import capture_user_loc, loc_or_unknown
 
 
 class Buffer(Resolvable):
@@ -61,6 +62,7 @@ class Buffer(Resolvable):
             self._name = f"buf_{self.__get_index()}"
         self._use_write_rtp = use_write_rtp
         self._tile = tile
+        self._user_loc = capture_user_loc(name=self._name)
 
     @property
     def tile(self) -> Tile | None:
@@ -112,10 +114,11 @@ class Buffer(Resolvable):
         if not self._op:
             if not self._tile:
                 raise ValueError("Cannot resolve buffer until it has been placed.")
-            self._op = buffer(
-                tile=self._tile.op,
-                datatype=self._arr_type,
-                name=self._name,
-                initial_value=self._initial_value,
-                use_write_rtp=self._use_write_rtp,
-            )
+            with loc_or_unknown(self._user_loc):
+                self._op = buffer(
+                    tile=self._tile.op,
+                    datatype=self._arr_type,
+                    name=self._name,
+                    initial_value=self._initial_value,
+                    use_write_rtp=self._use_write_rtp,
+                )

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -767,6 +767,12 @@ class ObjectFifoLink(ObjectFifoEndpoint, Resolvable):
         if tile.tile_type is None:
             tile.tile_type = AIETileType.MemTile
         ObjectFifoEndpoint.__init__(self, tile)
+        # Source loc points at the user's join/split/forward call site.
+        link_name = "link_{}_to_{}".format(
+            "_".join(s.name for s in self._srcs),
+            "_".join(d.name for d in self._dsts),
+        )
+        self._user_loc = capture_user_loc(name=link_name)
 
     def resolve(
         self,
@@ -788,6 +794,7 @@ class ObjectFifoLink(ObjectFifoEndpoint, Resolvable):
                 d.resolve()
             src_ops = [s.op for s in self._srcs]
             dst_ops = [d.op for d in self._dsts]
-            self._op = object_fifo_link(
-                src_ops, dst_ops, self._src_offsets, self._dst_offsets
-            )
+            with loc_or_unknown(self._user_loc):
+                self._op = object_fifo_link(
+                    src_ops, dst_ops, self._src_offsets, self._dst_offsets
+                )

--- a/python/iron/dataflow/objectfifo.py
+++ b/python/iron/dataflow/objectfifo.py
@@ -23,6 +23,7 @@ from ...util import single_elem_or_list_to_list
 from ..resolvable import Resolvable, NotResolvedError
 from .endpoint import ObjectFifoEndpoint
 from ..device import Device, Tile, AnyMemTile
+from .._loc import capture_user_loc, loc_or_unknown
 
 
 class ObjectFifo(Resolvable):
@@ -82,6 +83,7 @@ class ObjectFifo(Resolvable):
         self._resolving = False
         self._iter_count: int | None = None
         self._init_values: list[np.ndarray] | None = init_values
+        self._user_loc = capture_user_loc(name=self.name)
 
     @classmethod
     def __get_index(cls) -> int:
@@ -290,25 +292,26 @@ class ObjectFifo(Resolvable):
                 for con in self._cons
             ]
 
-            self._op = object_fifo(
-                self.name,
-                self._prod_tile_op(),
-                self._cons_tiles_ops(),
-                self._get_depths(),
-                np_ndarray_type_to_memref_type(self._obj_type),
-                dimensionsToStream=self._dims_to_stream,
-                dimensionsFromStreamPerConsumer=dims_from_stream_per_cons,
-                plio=self._plio,
-                padDimensions=self._pad_dimensions,
-                iter_count=self._iter_count,
-                initValues=self._init_values,
-            )
+            with loc_or_unknown(self._user_loc):
+                self._op = object_fifo(
+                    self.name,
+                    self._prod_tile_op(),
+                    self._cons_tiles_ops(),
+                    self._get_depths(),
+                    np_ndarray_type_to_memref_type(self._obj_type),
+                    dimensionsToStream=self._dims_to_stream,
+                    dimensionsFromStreamPerConsumer=dims_from_stream_per_cons,
+                    plio=self._plio,
+                    padDimensions=self._pad_dimensions,
+                    iter_count=self._iter_count,
+                    initValues=self._init_values,
+                )
 
-            if isinstance(self._prod.endpoint, ObjectFifoLink):
-                self._prod.endpoint.resolve()
-            for con in self._cons:
-                if isinstance(con.endpoint, ObjectFifoLink):
-                    con.endpoint.resolve()
+                if isinstance(self._prod.endpoint, ObjectFifoLink):
+                    self._prod.endpoint.resolve()
+                for con in self._cons:
+                    if isinstance(con.endpoint, ObjectFifoLink):
+                        con.endpoint.resolve()
 
     def _acquire(
         self,

--- a/python/iron/kernel.py
+++ b/python/iron/kernel.py
@@ -19,6 +19,7 @@ from ..helpers.dialects.func import call
 from ..dialects.aie import external_func
 from .resolvable import Resolvable
 from .buffer import Buffer
+from ._loc import capture_user_loc, loc_or_unknown
 
 
 class BaseKernel(Resolvable):
@@ -40,6 +41,7 @@ class BaseKernel(Resolvable):
         self._name = name
         self._arg_types = arg_types
         self._op: FuncOp | None = None
+        self._user_loc = capture_user_loc(name=name)
 
     def tile_size(self, arg_index: int = 0) -> int:
         """Return the first dimension of the array argument at ``arg_index``.
@@ -127,9 +129,12 @@ class Kernel(BaseKernel):
         ip: ir.InsertionPoint | None = None,
     ) -> None:
         if not self._op:
-            self._op = external_func(
-                self._name, inputs=self._arg_types, link_with=self._object_file_name
-            )
+            with loc_or_unknown(self._user_loc):
+                self._op = external_func(
+                    self._name,
+                    inputs=self._arg_types,
+                    link_with=self._object_file_name,
+                )
 
 
 class ExternalFunction(Kernel):

--- a/python/iron/runtime/dmatask.py
+++ b/python/iron/runtime/dmatask.py
@@ -16,6 +16,7 @@ from .data import RuntimeData
 from ...helpers.taplib import TensorAccessPattern
 from .task import RuntimeTask
 from .taskgroup import RuntimeTaskGroup
+from .._loc import loc_or_unknown
 
 
 class DMATask(RuntimeTask):
@@ -26,6 +27,7 @@ class DMATask(RuntimeTask):
         tap: TensorAccessPattern,
         task_group: RuntimeTaskGroup | None = None,
         wait: bool = False,
+        user_loc: ir.Location | None = None,
     ):
         """A RuntimeTask that will resolve to a DMA Operation.
 
@@ -41,6 +43,7 @@ class DMATask(RuntimeTask):
         self._tap = tap
         self._wait = wait
         self._task = None
+        self._user_loc = user_loc
         RuntimeTask.__init__(self, task_group)
 
     def will_wait(self) -> bool:
@@ -65,10 +68,11 @@ class DMATask(RuntimeTask):
         loc: ir.Location | None = None,
         ip: ir.InsertionPoint | None = None,
     ) -> None:
-        self._task = shim_dma_single_bd_task(
-            self._object_fifo.op,
-            self._rt_data.op,
-            tap=self._tap,
-            issue_token=self._wait,
-        )
-        dma_start_task(self._task)
+        with loc_or_unknown(self._user_loc):
+            self._task = shim_dma_single_bd_task(
+                self._object_fifo.op,
+                self._rt_data.op,
+                tap=self._tap,
+                issue_token=self._wait,
+            )
+            dma_start_task(self._task)

--- a/python/iron/runtime/dmatask.py
+++ b/python/iron/runtime/dmatask.py
@@ -51,6 +51,10 @@ class DMATask(RuntimeTask):
         return self._wait
 
     @property
+    def user_loc(self):
+        return self._user_loc
+
+    @property
     def fifo(self) -> ObjectFifoHandle:
         """The ObjectFifoHandle associated with this task."""
         return self._object_fifo

--- a/python/iron/runtime/runtime.py
+++ b/python/iron/runtime/runtime.py
@@ -38,6 +38,7 @@ from .task import (
     InlineOpRuntimeTask,
     FinishTaskGroupTask,
 )
+from .._loc import capture_user_loc
 
 
 class Runtime(Resolvable):
@@ -173,7 +174,16 @@ class Runtime(Resolvable):
 
         in_fifo.endpoint = rt_endpoint
         self._fifos.add(in_fifo)
-        self._tasks.append(DMATask(in_fifo, source, tap, task_group, wait))
+        self._tasks.append(
+            DMATask(
+                in_fifo,
+                source,
+                tap,
+                task_group,
+                wait,
+                user_loc=capture_user_loc(name=f"fill({in_fifo.name})"),
+            )
+        )
 
     def drain(
         self,
@@ -210,7 +220,16 @@ class Runtime(Resolvable):
 
         out_fifo.endpoint = rt_endpoint
         self._fifos.add(out_fifo)
-        self._tasks.append(DMATask(out_fifo, dest, tap, task_group, wait))
+        self._tasks.append(
+            DMATask(
+                out_fifo,
+                dest,
+                tap,
+                task_group,
+                wait,
+                user_loc=capture_user_loc(name=f"drain({out_fifo.name})"),
+            )
+        )
 
     def start(self, *args: Worker):
         """A placeholder operation to indicate that one or more Worker should be started on the device.

--- a/python/iron/runtime/runtime.py
+++ b/python/iron/runtime/runtime.py
@@ -256,7 +256,14 @@ class Runtime(Resolvable):
             inline_args (list): The state the function needs to execute.
         """
         # TODO: should filter args based on some criteria??
-        self._tasks.append(InlineOpRuntimeTask(inline_func, inline_args))
+        fn_name = getattr(inline_func, "__name__", "inline_ops")
+        self._tasks.append(
+            InlineOpRuntimeTask(
+                inline_func,
+                inline_args,
+                user_loc=capture_user_loc(name=f"inline_ops({fn_name})"),
+            )
+        )
 
     def enable_trace(
         self,
@@ -308,7 +315,11 @@ class Runtime(Resolvable):
             barrier (WorkerRuntimeBarrier): The WorkerRuntimeBarrier to set.
             value (int): The value to set the barrier to.
         """
-        self._tasks.append(_BarrierSetOp(barrier, value))
+        self._tasks.append(
+            _BarrierSetOp(
+                barrier, value, user_loc=capture_user_loc(name="set_barrier")
+            )
+        )
 
     @property
     def workers(self) -> list[Worker]:

--- a/python/iron/runtime/runtime.py
+++ b/python/iron/runtime/runtime.py
@@ -38,7 +38,7 @@ from .task import (
     InlineOpRuntimeTask,
     FinishTaskGroupTask,
 )
-from .._loc import capture_user_loc
+from .._loc import capture_user_loc, loc_or_unknown
 
 
 class Runtime(Resolvable):
@@ -368,25 +368,28 @@ class Runtime(Resolvable):
 
                 # We want to keep order, EXCEPT do waits before frees
                 wait_tasks = [
-                    (fn, args) for (fn, args) in actions if fn == dma_await_task
+                    action for action in actions if action[0] == dma_await_task
                 ]
                 free_tasks = [
-                    (fn, args) for (fn, args) in actions if fn == dma_free_task
+                    action for action in actions if action[0] == dma_free_task
                 ]
 
                 # Check for anything known -- this shouldn't happen, but we'll catch it gracefully anyways.
                 if len(wait_tasks) + len(free_tasks) != len(actions):
                     unknown_actions = [
-                        (fn, args)
-                        for (fn, args) in actions
-                        if fn != dma_await_task and fn != dma_free_task
+                        action
+                        for action in actions
+                        if action[0] != dma_await_task
+                        and action[0] != dma_free_task
                     ]
                     raise Exception(
-                        f"Unknown action type detected: {','.join(unknown_actions)}"
+                        "Unknown action type detected: "
+                        f"{', '.join(str(action[0]) for action in unknown_actions)}"
                     )
 
-                for fn, args in wait_tasks + free_tasks:
-                    fn(*args)
+                for fn, args, user_loc in wait_tasks + free_tasks:
+                    with loc_or_unknown(user_loc):
+                        fn(*args)
                 task_group_actions[tg] = None
 
             default_task_group = self.task_group()
@@ -404,11 +407,11 @@ class Runtime(Resolvable):
                         current_task_group = default_task_group
                     if task.will_wait():
                         task_group_actions[current_task_group].append(
-                            (dma_await_task, [task.task])
+                            (dma_await_task, [task.task], task.user_loc)
                         )
                     else:
                         task_group_actions[current_task_group].append(
-                            (dma_free_task, [task.task])
+                            (dma_free_task, [task.task], task.user_loc)
                         )
                 if isinstance(task, FinishTaskGroupTask):
                     finish_task_group(task.task_group, task_group_actions)

--- a/python/iron/runtime/task.py
+++ b/python/iron/runtime/task.py
@@ -13,6 +13,7 @@ from ..buffer import Buffer
 from ..resolvable import Resolvable
 from ..worker import Worker
 from .taskgroup import RuntimeTaskGroup
+from .._loc import loc_or_unknown
 
 
 class RuntimeTask(Resolvable):
@@ -64,7 +65,11 @@ class InlineOpRuntimeTask(RuntimeTask):
     in a lower-level style of IRON. This can be especially useful for tracing."""
 
     def __init__(
-        self, fn: Callable, args: list, task_group: RuntimeTaskGroup | None = None
+        self,
+        fn: Callable,
+        args: list,
+        task_group: RuntimeTaskGroup | None = None,
+        user_loc=None,
     ):
         """Construct an InlineOpRuntimeTask.
 
@@ -72,10 +77,12 @@ class InlineOpRuntimeTask(RuntimeTask):
             fn (Callable): The function that will generate ops. It will be run within an MLIR module context.
             args (list): The arguments for the task: this should included objects such as Buffers used by the function.
             task_group (RuntimeTaskGroup | None, optional): The TaskGroup to associated these operation with. Defaults to None.
+            user_loc (CapturedLoc | None, optional): The user-source loc captured at the call site of Runtime.inline_ops.
         """
         # TODO: should validate somehow?
         self._fn = fn
         self._args = args
+        self._user_loc = user_loc
         RuntimeTask.__init__(self, task_group)
 
     @staticmethod
@@ -92,6 +99,7 @@ class InlineOpRuntimeTask(RuntimeTask):
         loc: ir.Location | None = None,
         ip: ir.InsertionPoint | None = None,
     ) -> None:
-        for arg in self._args:
-            InlineOpRuntimeTask._resolve_buffers(arg, loc, ip)
-        self._fn(*self._args)
+        with loc_or_unknown(self._user_loc):
+            for arg in self._args:
+                InlineOpRuntimeTask._resolve_buffers(arg, loc, ip)
+            self._fn(*self._args)

--- a/python/iron/worker.py
+++ b/python/iron/worker.py
@@ -214,19 +214,23 @@ class WorkerRuntimeBarrier:
 class _BarrierSetOp(Resolvable):
     """A resolvable instance of a WorkerRuntimeBarrier. This should not be used directly."""
 
-    def __init__(self, barrier: WorkerRuntimeBarrier, value: int):
+    def __init__(self, barrier: WorkerRuntimeBarrier, value: int, user_loc=None):
         """Construct a _BarrierSetOp.
 
         Args:
             barrier (WorkerRuntimeBarrier): The barrier whose value will be set.
             value (int): The value to set.
+            user_loc (CapturedLoc | None, optional): User-source loc captured at the
+                Runtime.set_barrier call site.
         """
         self.barrier: WorkerRuntimeBarrier = barrier
         self.value: int = value
+        self._user_loc = user_loc
 
     def resolve(
         self,
         loc: ir.Location | None = None,
         ip: ir.InsertionPoint | None = None,
     ) -> None:
-        self.barrier._set_barrier_value(self.value)
+        with loc_or_unknown(self._user_loc):
+            self.barrier._set_barrier_value(self.value)

--- a/python/iron/worker.py
+++ b/python/iron/worker.py
@@ -20,6 +20,7 @@ from .dataflow.objectfifo import ObjectFifoHandle, ObjectFifo
 from .dataflow.endpoint import ObjectFifoEndpoint
 from .buffer import Buffer
 from .resolvable import Resolvable
+from ._loc import capture_user_loc, loc_or_unknown
 
 
 class Worker(ObjectFifoEndpoint):
@@ -115,6 +116,9 @@ class Worker(ObjectFifoEndpoint):
             # func.func declaration. Other unrecognized args are assumed to be
             # metaprogramming values (Python scalars, etc.).
 
+        fn_name = getattr(self.core_fn, "__name__", None)
+        self._user_loc = capture_user_loc(name=fn_name)
+
     @property
     def fifos(self) -> list[ObjectFifoHandle]:
         """Returns a list of ObjectFifoHandles given to the Worker via fn_args.
@@ -142,16 +146,17 @@ class Worker(ObjectFifoEndpoint):
             raise ValueError("Must place Worker before it can be resolved.")
         my_tile = self._tile.op
 
-        # Create the necessary locks for the core operation to synchronize with the runtime sequence
-        # and register them in the corresponding barriers.
-        for barrier in self._barriers:
-            l = lock(my_tile)
-            barrier._add_worker_lock(l)
+        with loc_or_unknown(self._user_loc):
+            # Create the necessary locks for the core operation to synchronize with the runtime sequence
+            # and register them in the corresponding barriers.
+            for barrier in self._barriers:
+                l = lock(my_tile)
+                barrier._add_worker_lock(l)
 
-        @core(my_tile, stack_size=self.stack_size)
-        def core_body():
-            for _ in range_(sys.maxsize) if self._while_true else range(1):
-                self.core_fn(*self.fn_args)
+            @core(my_tile, stack_size=self.stack_size)
+            def core_body():
+                for _ in range_(sys.maxsize) if self._while_true else range(1):
+                    self.core_fn(*self.fn_args)
 
 
 class WorkerRuntimeBarrier:

--- a/python/utils/compile/utils.py
+++ b/python/utils/compile/utils.py
@@ -104,6 +104,8 @@ def compile_mlir_module(
         "--no-compile-host",
         "--no-xchesscc",
         "--no-xbridge",
+        "--dump-intermediates",
+        "--keep-loc",
         f"--peano={config.peano_install_dir()}",
     ]
     if insts_path:
@@ -134,7 +136,10 @@ def compile_mlir_module(
             )
         mlir_file = os.path.join(work_dir, "aie.mlir")
         with open(mlir_file, "w") as f:
-            f.write(str(mlir_module))
+            if hasattr(mlir_module, "operation"):
+                f.write(mlir_module.operation.get_asm(enable_debug_info=True))
+            else:
+                f.write(str(mlir_module))
         result = subprocess.run(
             [aiecc_bin, mlir_file] + args, capture_output=True, text=True
         )

--- a/python/utils/jit.py
+++ b/python/utils/jit.py
@@ -153,7 +153,9 @@ def jit(function=None, use_cache=True):
             if not effective_use_cache or not xclbin_exists or not inst_exists:
                 try:
                     with open(mlir_path, "w", encoding="utf-8") as f:
-                        print(mlir_module, file=f)
+                        f.write(
+                            mlir_module.operation.get_asm(enable_debug_info=True)
+                        )
 
                     # Compile ExternalFunctions from inside the JIT compilation directory
                     for func in external_kernels:

--- a/test/Conversion/AIEToConfiguration/loc_preservation.mlir
+++ b/test/Conversion/AIEToConfiguration/loc_preservation.mlir
@@ -8,24 +8,31 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Verifies --convert-aie-to-control-packets attaches the source DeviceOp's
-// loc to the synthesized aie.runtime_sequence and aiex.control_packet ops.
+// Verifies --convert-aie-to-control-packets propagates source op locations
+// onto the synthesized aiex.control_packet ops via AIERTControl's
+// instruction-range bracketing (Phase 3). The runtime_sequence itself
+// inherits the device loc when synthesized on demand.
 
 // RUN: aie-opt --convert-aie-to-control-packets="elf-dir=%S/convert_aie_to_ctrl_pkts_elfs/" --mlir-print-debuginfo %s | FileCheck %s
 
 #device_loc = loc("user_design.py":42:4)
+#core_user_loc = loc("user_design.py":80:4)
+#core_named = loc("worker_2"(#core_user_loc))
 
 aie.device(npu1_1col) {
   %12 = aie.tile(0, 2)
   %buf = aie.buffer(%12) : memref<256xi32>
   %4 = aie.core(%12) {
     aie.end
-  } { elf_file = "core_0_2.elf" }
+  } { elf_file = "core_0_2.elf" } loc(#core_named)
 } loc(#device_loc)
 
-// At least one synthesized aiex.control_packet inside the new
-// runtime_sequence carries the device's loc, and the runtime_sequence
-// itself does too. (The pass creates the runtime_sequence on demand.)
+// runtime_sequence is synthesized on demand and inherits the device loc.
 // CHECK-DAG: aie.runtime_sequence @configure() {{[{][[:space:]]*$}}
-// CHECK-DAG: aiex.control_packet {{.*}} loc(#[[DEVLOC:loc[0-9]*]])
-// CHECK-DAG: #[[DEVLOC]] = loc("user_design.py":42:4)
+
+// At least one synthesized control_packet carries the CoreOp's IRON-style
+// NameLoc — produced by AIERTControl::addCoreEnable's TxnLocBracket around
+// the XAie_CoreEnable call.
+// CHECK-DAG: #[[USERLOC:loc[0-9]*]] = loc("user_design.py":80:4)
+// CHECK-DAG: #[[CORELOC:loc[0-9]*]] = loc("worker_2"(#[[USERLOC]]))
+// CHECK-DAG: aiex.control_packet {{.*}} loc(#[[CORELOC]])

--- a/test/Conversion/AIEToConfiguration/loc_preservation.mlir
+++ b/test/Conversion/AIEToConfiguration/loc_preservation.mlir
@@ -1,0 +1,31 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies --convert-aie-to-control-packets attaches the source DeviceOp's
+// loc to the synthesized aie.runtime_sequence and aiex.control_packet ops.
+
+// RUN: aie-opt --convert-aie-to-control-packets="elf-dir=%S/convert_aie_to_ctrl_pkts_elfs/" --mlir-print-debuginfo %s | FileCheck %s
+
+#device_loc = loc("user_design.py":42:4)
+
+aie.device(npu1_1col) {
+  %12 = aie.tile(0, 2)
+  %buf = aie.buffer(%12) : memref<256xi32>
+  %4 = aie.core(%12) {
+    aie.end
+  } { elf_file = "core_0_2.elf" }
+} loc(#device_loc)
+
+// At least one synthesized aiex.control_packet inside the new
+// runtime_sequence carries the device's loc, and the runtime_sequence
+// itself does too. (The pass creates the runtime_sequence on demand.)
+// CHECK-DAG: aie.runtime_sequence @configure() {{[{][[:space:]]*$}}
+// CHECK-DAG: aiex.control_packet {{.*}} loc(#[[DEVLOC:loc[0-9]*]])
+// CHECK-DAG: #[[DEVLOC]] = loc("user_design.py":42:4)

--- a/test/Conversion/AIEToConfiguration/loc_roundtrip.mlir
+++ b/test/Conversion/AIEToConfiguration/loc_roundtrip.mlir
@@ -1,0 +1,35 @@
+//===- loc_roundtrip.mlir ----------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that --convert-aie-to-transaction preserves source op locations
+// across the aie-rt round-trip. AIERTControl::TxnLocBracket scopes capture
+// the lock op's loc around the XAie_LockSetValue call; AIEToConfiguration
+// then reads ctl.getTxnInstrLocs() and applies those locations to the
+// re-emitted aiex.npu.write32 ops instead of the device fallback location.
+
+// RUN: aie-opt --convert-aie-to-transaction="elf-dir=%S/convert_aie_to_ctrl_pkts_elfs/" --mlir-print-debuginfo %s | FileCheck %s
+
+#device_loc = loc("device.mlir":1:1)
+#user_lock_loc = loc("user_program.py":17:8)
+#user_lock_name = loc("of_in_lock0"(#user_lock_loc))
+
+aie.device(npu1_1col) {
+  %t02 = aie.tile(0, 2)
+  %lock = aie.lock(%t02, 0) { init = 1 : i32, sym_name = "lk" } loc(#user_lock_name)
+  %4 = aie.core(%t02) {
+    aie.end
+  } { elf_file = "core_0_2.elf" }
+} loc(#device_loc)
+
+// At least one synthesized aiex.npu.write32 (from XAie_LockSetValue) carries
+// the IRON-style NameLoc pointing at user_program.py:17, NOT the device loc
+// fallback. The bracketing in AIERT::initLocks attributes the cmds produced
+// by the explicit-init lock walk to the LockOp's loc.
+// CHECK-DAG: #[[USERLOC:loc[0-9]*]] = loc("user_program.py":17:8)
+// CHECK-DAG: #[[LOCKLOC:loc[0-9]*]] = loc("of_in_lock0"(#[[USERLOC]]))
+// CHECK-DAG: aiex.npu.write32{{.*}}loc(#[[LOCKLOC]])

--- a/test/Targets/NPU/loc_sidecar.mlir
+++ b/test/Targets/NPU/loc_sidecar.mlir
@@ -19,11 +19,16 @@
 #name_bw  = loc("dma_task"(#user_bw))
 #name_zero = loc("zero_reg"(#user_zero))
 
+// Phase 4 — pre-fuse a couple of checkpoint stages onto one entry so we can
+// verify locToJSON's metadata surfacing.
+#stage_inner = loc(fused<"checkpoint:input">[#name_w32])
+#stage_w32 = loc(fused<"checkpoint:dma-to-npu">[#stage_inner])
+
 module {
   aie.device(npu1) {
     memref.global "private" constant @write_data : memref<4xi32> = dense<[1, 2, 3, 4]>
     aie.runtime_sequence(%arg0: memref<16xf32>) {
-      aiex.npu.write32 { address = 0xabc00def : ui32, value = 0x42 : ui32 } loc(#name_w32)
+      aiex.npu.write32 { address = 0xabc00def : ui32, value = 0x42 : ui32 } loc(#stage_w32)
       aiex.npu.write32 { address = 0x0 : ui32, value = 0x1 : ui32 } loc(#name_zero)
       %0 = memref.get_global @write_data : memref<4xi32>
       aiex.npu.blockwrite (%0) { address = 0x12345678 : ui32 } : memref<4xi32> loc(#name_bw)
@@ -37,13 +42,17 @@ module {
 // CHECK-DAG: "operations":
 
 // Per-op entries: opcode, source op name, address, source location with
-// the IRON NameLoc carrying the user file:line.
+// the IRON NameLoc carrying the user file:line. The write32 entry's loc
+// is wrapped in two checkpoint stages (Phase 4); locToJSON surfaces them
+// as "checkpoint" keys (prefix stripped).
 // CHECK-DAG: "opcode": "WRITE32"
 // CHECK-DAG: "source_op": "aiex.npu.write32"
 // CHECK-DAG: "address": "0xABC00DEF"
 // CHECK-DAG: "name": "of_in"
 // CHECK-DAG: "file": "user.py"
 // CHECK-DAG: "line": 42
+// CHECK-DAG: "checkpoint": "input"
+// CHECK-DAG: "checkpoint": "dma-to-npu"
 
 // Address zero is a real address, not the "no address" sentinel.
 // CHECK-DAG: "address": "0x0"

--- a/test/Targets/NPU/loc_sidecar.mlir
+++ b/test/Targets/NPU/loc_sidecar.mlir
@@ -1,0 +1,49 @@
+//===- loc_sidecar.mlir -----------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies aie-translate --aie-npu-to-binary-locmap emits a JSON sidecar
+// keying each transaction word's byte_offset to the source aiex.npu.* op's
+// MLIR Location, including IRON-style NameLoc names from Phase 1 capture.
+
+// RUN: aie-translate --aie-npu-to-binary-locmap %s | FileCheck %s
+
+#user_w32 = loc("user.py":42:4)
+#user_bw  = loc("user.py":50:4)
+#name_w32 = loc("of_in"(#user_w32))
+#name_bw  = loc("dma_task"(#user_bw))
+
+module {
+  aie.device(npu1) {
+    memref.global "private" constant @write_data : memref<4xi32> = dense<[1, 2, 3, 4]>
+    aie.runtime_sequence(%arg0: memref<16xf32>) {
+      aiex.npu.write32 { address = 0xabc00def : ui32, value = 0x42 : ui32 } loc(#name_w32)
+      %0 = memref.get_global @write_data : memref<4xi32>
+      aiex.npu.blockwrite (%0) { address = 0x12345678 : ui32 } : memref<4xi32> loc(#name_bw)
+    }
+  }
+}
+
+// JSON header
+// CHECK-DAG: "version": 1
+// CHECK-DAG: "device":
+// CHECK-DAG: "operations":
+
+// Per-op entries: opcode, source op name, address, source location with
+// the IRON NameLoc carrying the user file:line.
+// CHECK-DAG: "opcode": "WRITE32"
+// CHECK-DAG: "source_op": "aiex.npu.write32"
+// CHECK-DAG: "address": "0xABC00DEF"
+// CHECK-DAG: "name": "of_in"
+// CHECK-DAG: "file": "user.py"
+// CHECK-DAG: "line": 42
+
+// CHECK-DAG: "opcode": "BLOCKWRITE"
+// CHECK-DAG: "source_op": "aiex.npu.blockwrite"
+// CHECK-DAG: "address": "0x12345678"
+// CHECK-DAG: "name": "dma_task"
+// CHECK-DAG: "line": 50

--- a/test/Targets/NPU/loc_sidecar.mlir
+++ b/test/Targets/NPU/loc_sidecar.mlir
@@ -14,14 +14,17 @@
 
 #user_w32 = loc("user.py":42:4)
 #user_bw  = loc("user.py":50:4)
+#user_zero = loc("user.py":60:4)
 #name_w32 = loc("of_in"(#user_w32))
 #name_bw  = loc("dma_task"(#user_bw))
+#name_zero = loc("zero_reg"(#user_zero))
 
 module {
   aie.device(npu1) {
     memref.global "private" constant @write_data : memref<4xi32> = dense<[1, 2, 3, 4]>
     aie.runtime_sequence(%arg0: memref<16xf32>) {
       aiex.npu.write32 { address = 0xabc00def : ui32, value = 0x42 : ui32 } loc(#name_w32)
+      aiex.npu.write32 { address = 0x0 : ui32, value = 0x1 : ui32 } loc(#name_zero)
       %0 = memref.get_global @write_data : memref<4xi32>
       aiex.npu.blockwrite (%0) { address = 0x12345678 : ui32 } : memref<4xi32> loc(#name_bw)
     }
@@ -41,6 +44,11 @@ module {
 // CHECK-DAG: "name": "of_in"
 // CHECK-DAG: "file": "user.py"
 // CHECK-DAG: "line": 42
+
+// Address zero is a real address, not the "no address" sentinel.
+// CHECK-DAG: "address": "0x0"
+// CHECK-DAG: "name": "zero_reg"
+// CHECK-DAG: "line": 60
 
 // CHECK-DAG: "opcode": "BLOCKWRITE"
 // CHECK-DAG: "source_op": "aiex.npu.blockwrite"

--- a/test/aiecc/cpp_basic.mlir
+++ b/test/aiecc/cpp_basic.mlir
@@ -14,9 +14,23 @@
 // RUN: aiecc --no-xchesscc --no-xbridge -n --verbose %s | FileCheck %s --check-prefix=DRY
 // RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-npu-insts --verbose %s 2>&1 | FileCheck %s --check-prefix=NPU
 
+// Phase 4 — checkpoint dumps inside runNpuLoweringPipeline (split for
+// intermediate visibility). Confirm each new intermediate file exists, and
+// that the chain accumulated by dma_to_npu.mlir contains both the early
+// 'input' and late 'dma-to-npu' stage labels.
+// RUN: rm -rf %t_npu_tmp && mkdir -p %t_npu_tmp
+// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-npu-insts --keep-loc --dump-intermediates --tmpdir=%t_npu_tmp %s
+// RUN: test -f %t_npu_tmp/input.mlir
+// RUN: test -f %t_npu_tmp/objectfifo_expanded.mlir
+// RUN: test -f %t_npu_tmp/main_bd_chains_materialized.mlir
+// RUN: test -f %t_npu_tmp/main_dma_tasks_to_npu.mlir
+// RUN: test -f %t_npu_tmp/main_dma_to_npu.mlir
+// RUN: test -f %t_npu_tmp/main_set_lock_lowered.mlir
+// RUN: test -f %t_npu_tmp/main_npu_lowered.mlir
+// RUN: FileCheck %s --check-prefix=DMA_NPU < %t_npu_tmp/main_dma_to_npu.mlir
+
 // CHECK: Successfully parsed input file
 // CHECK: Found 1 AIE device
-// CHECK: Running resource allocation pipeline in-memory
 // CHECK: Resource allocation pipeline completed successfully
 // CHECK: Running routing pipeline in-memory
 // CHECK: Routing pipeline completed successfully
@@ -27,6 +41,12 @@
 
 // NPU: Generating NPU instructions for device
 // NPU: Compilation completed successfully
+
+// By the time we get to dma_to_npu.mlir, the chain has accumulated several
+// stage labels. We assert the latest (dma-to-npu) and the earliest (input).
+// DMA_NPU-DAG: fused<"checkpoint:dma-to-npu">
+// DMA_NPU-DAG: fused<"checkpoint:input">
+// DMA_NPU-DAG: fused<"checkpoint:objectfifo-expanded">
 
 module {
   aie.device(npu1_1col) {

--- a/test/aiecc/cpp_ctrlpkt.mlir
+++ b/test/aiecc/cpp_ctrlpkt.mlir
@@ -12,7 +12,9 @@
 
 // Preprocess with overlay (matching ctrl_packet_reconfig test flow)
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %s -o %t_overlay.mlir
-// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --verbose %t_overlay.mlir 2>&1 | FileCheck %s
+// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --dump-intermediates --tmpdir=%t_ctrlpkt_tmp --verbose %t_overlay.mlir 2>&1 | FileCheck %s
+// RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/main_ctrlpkt.mlir
+// RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/input_with_addresses.mlir
 
 // CHECK: Generating control packets for device
 // CHECK: Running control packet pipeline in-memory
@@ -20,6 +22,8 @@
 // CHECK: Running control packet DMA pipeline in-memory
 // CHECK: Wrote {{[0-9]+}} DMA sequence instructions to
 // CHECK: Compilation completed successfully
+
+// DUMP: loc(
 
 module {
   aie.device(npu1) {

--- a/test/aiecc/cpp_ctrlpkt.mlir
+++ b/test/aiecc/cpp_ctrlpkt.mlir
@@ -12,15 +12,19 @@
 
 // Preprocess with overlay (matching ctrl_packet_reconfig test flow)
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %s -o %t_overlay.mlir
-// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --dump-intermediates --tmpdir=%t_ctrlpkt_tmp --verbose %t_overlay.mlir 2>&1 | FileCheck %s
+// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --keep-loc --dump-intermediates --tmpdir=%t_ctrlpkt_tmp --verbose %t_overlay.mlir 2>&1 | FileCheck %s
 // RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/main_ctrlpkt.mlir
 // RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/input_with_addresses.mlir
+// RUN: test -f %t_ctrlpkt.bin.locmap.json
+// RUN: test -f %t_dma_seq.bin.locmap.json
 
 // CHECK: Generating control packets for device
 // CHECK: Running control packet pipeline in-memory
 // CHECK: Wrote {{[0-9]+}} control packet instructions to
+// CHECK: Wrote {{[0-9]+}} locmap entries to: {{.*}}ctrlpkt.bin.locmap.json
 // CHECK: Running control packet DMA pipeline in-memory
 // CHECK: Wrote {{[0-9]+}} DMA sequence instructions to
+// CHECK: Wrote {{[0-9]+}} locmap entries to: {{.*}}dma_seq.bin.locmap.json
 // CHECK: Compilation completed successfully
 
 // DUMP: loc(

--- a/test/aiecc/cpp_ctrlpkt.mlir
+++ b/test/aiecc/cpp_ctrlpkt.mlir
@@ -19,6 +19,20 @@
 // RUN: test -f %t_dma_seq.bin.locmap.json
 // RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/main_ctrlpkt.mlir
 
+// Phase 4 — checkpoint dumps that fire in the control-packet flow must
+// exist alongside the legacy intermediates. (The NPU-lowering subpipeline
+// dumps — bd_chains_materialized, dma_to_npu, set_lock_lowered — are
+// exercised by a non-ctrlpkt flow and not asserted here.)
+// RUN: test -f %t_ctrlpkt_tmp/input.mlir
+// RUN: test -f %t_ctrlpkt_tmp/input_physical.mlir
+// RUN: test -f %t_ctrlpkt_tmp/objectfifo_expanded.mlir
+// RUN: test -f %t_ctrlpkt_tmp/main_physical_with_elfs.mlir
+// RUN: test -f %t_ctrlpkt_tmp/main_ctrlpkt.mlir
+// RUN: test -f %t_ctrlpkt_tmp/main_ctrlpkt_dma_seq.mlir
+// RUN: FileCheck %s --check-prefix=INPUT_STAGE < %t_ctrlpkt_tmp/input.mlir
+// RUN: FileCheck %s --check-prefix=OBJFIFO_STAGE < %t_ctrlpkt_tmp/objectfifo_expanded.mlir
+// RUN: FileCheck %s --check-prefix=JSON < %t_ctrlpkt.bin.locmap.json
+
 // CHECK: Generating control packets for device
 // CHECK: Running control packet pipeline in-memory
 // CHECK: Wrote {{[0-9]+}} control packet instructions to
@@ -29,6 +43,19 @@
 // CHECK: Compilation completed successfully
 
 // DUMP: loc(
+
+// Every op in input.mlir is wrapped in fused<"checkpoint:input">.
+// INPUT_STAGE-DAG: fused<"checkpoint:input">
+
+// By the time we get to objectfifo_expanded.mlir, the chain has accumulated
+// stage labels for input, input-physical, and objectfifo-expanded.
+// OBJFIFO_STAGE-DAG: fused<"checkpoint:objectfifo-expanded">
+// OBJFIFO_STAGE-DAG: fused<"checkpoint:input">
+
+// The locmap JSON sidecar surfaces the checkpoint metadata as a top-level
+// "checkpoint" key on each fused level (label "checkpoint:" prefix is
+// stripped by emitNpuLocmapJSON for ergonomics).
+// JSON-DAG: "checkpoint": "input"
 
 module {
   aie.device(npu1) {

--- a/test/aiecc/cpp_ctrlpkt.mlir
+++ b/test/aiecc/cpp_ctrlpkt.mlir
@@ -12,11 +12,12 @@
 
 // Preprocess with overlay (matching ctrl_packet_reconfig test flow)
 // RUN: aie-opt -aie-generate-column-control-overlay="route-shim-to-tile-ctrl=true" %s -o %t_overlay.mlir
-// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --keep-loc --dump-intermediates --tmpdir=%t_ctrlpkt_tmp --verbose %t_overlay.mlir 2>&1 | FileCheck %s
+// RUN: aiecc --no-xchesscc --no-xbridge --aie-generate-ctrlpkt --keep-loc --dump-intermediates --tmpdir=%t_ctrlpkt_tmp --verbose --ctrlpkt-name=%t_ctrlpkt.bin --ctrlpkt-dma-seq-name=%t_dma_seq.bin %t_overlay.mlir 2>&1 | FileCheck %s
 // RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/main_ctrlpkt.mlir
 // RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/input_with_addresses.mlir
 // RUN: test -f %t_ctrlpkt.bin.locmap.json
 // RUN: test -f %t_dma_seq.bin.locmap.json
+// RUN: FileCheck %s --check-prefix=DUMP < %t_ctrlpkt_tmp/main_ctrlpkt.mlir
 
 // CHECK: Generating control packets for device
 // CHECK: Running control packet pipeline in-memory

--- a/test/create-cores/loc_preservation.mlir
+++ b/test/create-cores/loc_preservation.mlir
@@ -47,16 +47,22 @@ module @loc_test {
  }
 }
 
-// AIECreateCores: synthesized core / mem / buffer for the call op carry
+// AIECreateCores: synthesized tile / core / end / mem / buffer for the call
+// op carry
 // the call's loc.
+// CHECK-DAG: aie.tile({{.*}}) loc(#[[CALLLOC:loc[0-9]*]])
+// CHECK-DAG: aie.mem({{.*}})
 // CHECK-DAG: aie.core({{.*}}) {{[{][[:space:]]*$}}
-// CHECK-DAG: } loc(#[[CALLLOC:loc[0-9]*]])
+// CHECK-DAG: aie.end loc(#[[CALLLOC]])
+// CHECK-DAG: } loc(#[[CALLLOC]])
 // CHECK-DAG: aie.buffer({{.*}}) : memref<256xi32> loc(#[[CALLLOC]])
 
 // AIELowerMemcpy: synthesized aie.flow / dma_start / dma_bd / use_token /
 // next_bd carry the memcpy's loc.
 // CHECK-DAG: aie.flow({{.*}}) loc(#[[MCLOC:loc[0-9]*]])
+// CHECK-DAG: aie.dma_start({{.*}}) loc(#[[MCLOC]])
 // CHECK-DAG: aie.dma_bd({{.*}}) loc(#[[MCLOC]])
+// CHECK-DAG: aie.next_bd {{.*}} loc(#[[MCLOC]])
 // CHECK-DAG: aiex.useToken {{.*}} loc(#[[MCLOC]])
 
 // CHECK-DAG: #[[CALLLOC]] = loc("user_design.py":42:4)

--- a/test/create-cores/loc_preservation.mlir
+++ b/test/create-cores/loc_preservation.mlir
@@ -55,7 +55,7 @@ module @loc_test {
 // AIECreateCores: synthesized tile / core / end / mem / buffer for the call
 // op carry
 // the call's loc.
-// CHECK-DAG: aie.tile({{.*}}) loc(#[[CALLLOC:loc[0-9]*]])
+// CHECK-DAG: aie.tile(3, 3) loc(#[[CALLLOC:loc[0-9]*]])
 // CHECK-DAG: aie.mem({{.*}})
 // CHECK-DAG: aie.core({{.*}}) {{[{][[:space:]]*$}}
 // CHECK-DAG: aie.end loc(#[[CALLLOC]])

--- a/test/create-cores/loc_preservation.mlir
+++ b/test/create-cores/loc_preservation.mlir
@@ -27,6 +27,7 @@ module @loc_test {
 
   %buf0 = memref.alloc() : memref<256xi32>
   %buf1 = memref.alloc() : memref<256xi32>
+  %buf2 = memref.alloc() : memref<256xi32>
 
   aiex.token(0) { sym_name = "token0" }
 
@@ -40,10 +41,14 @@ module @loc_test {
     aiex.useToken @token0(Release, 3)
     return
   }
+  func.func @task2(%arg0: memref<256xi32>) -> () {
+    return
+  }
 
   func.call @task0(%buf0) { aie.x = 1, aie.y = 1 } : (memref<256xi32>) -> () loc(#call_loc)
   aiex.memcpy @token0(1, 2) (%t11 : <%buf0, 0, 256>, %t22 : <%buf1, 0, 256>) : (memref<256xi32>, memref<256xi32>) loc(#memcpy_loc)
   func.call @task1(%buf1) { aie.x = 2, aie.y = 2 } : (memref<256xi32>) -> ()
+  func.call @task2(%buf2) { aie.x = 3, aie.y = 3 } : (memref<256xi32>) -> () loc(#call_loc)
  }
 }
 

--- a/test/create-cores/loc_preservation.mlir
+++ b/test/create-cores/loc_preservation.mlir
@@ -1,0 +1,63 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that:
+//  - --aie-create-cores forwards the source func.call op's location to the
+//    synthesized aie.tile / aie.buffer / aie.mem / aie.core / aie.end ops.
+//  - --aie-lower-memcpy forwards the source aiex.memcpy op's location to
+//    the synthesized aie.flow / aie.dma_start / aie.dma_bd / aiex.useToken
+//    / aie.next_bd ops.
+
+// RUN: aie-opt --aie-create-cores --aie-lower-memcpy --mlir-print-debuginfo %s | FileCheck %s
+
+#call_loc = loc("user_design.py":42:4)
+#memcpy_loc = loc("user_design.py":50:4)
+
+module @loc_test {
+ aie.device(xcvc1902) {
+  %t11 = aie.tile(1, 1)
+  %t22 = aie.tile(2, 2)
+
+  %buf0 = memref.alloc() : memref<256xi32>
+  %buf1 = memref.alloc() : memref<256xi32>
+
+  aiex.token(0) { sym_name = "token0" }
+
+  func.func @task0(%arg0: memref<256xi32>) -> () {
+    aiex.useToken @token0(Acquire, 0)
+    aiex.useToken @token0(Release, 1)
+    return
+  }
+  func.func @task1(%arg0: memref<256xi32>) -> () {
+    aiex.useToken @token0(Acquire, 2)
+    aiex.useToken @token0(Release, 3)
+    return
+  }
+
+  func.call @task0(%buf0) { aie.x = 1, aie.y = 1 } : (memref<256xi32>) -> () loc(#call_loc)
+  aiex.memcpy @token0(1, 2) (%t11 : <%buf0, 0, 256>, %t22 : <%buf1, 0, 256>) : (memref<256xi32>, memref<256xi32>) loc(#memcpy_loc)
+  func.call @task1(%buf1) { aie.x = 2, aie.y = 2 } : (memref<256xi32>) -> ()
+ }
+}
+
+// AIECreateCores: synthesized core / mem / buffer for the call op carry
+// the call's loc.
+// CHECK-DAG: aie.core({{.*}}) {{[{][[:space:]]*$}}
+// CHECK-DAG: } loc(#[[CALLLOC:loc[0-9]*]])
+// CHECK-DAG: aie.buffer({{.*}}) : memref<256xi32> loc(#[[CALLLOC]])
+
+// AIELowerMemcpy: synthesized aie.flow / dma_start / dma_bd / use_token /
+// next_bd carry the memcpy's loc.
+// CHECK-DAG: aie.flow({{.*}}) loc(#[[MCLOC:loc[0-9]*]])
+// CHECK-DAG: aie.dma_bd({{.*}}) loc(#[[MCLOC]])
+// CHECK-DAG: aiex.useToken {{.*}} loc(#[[MCLOC]])
+
+// CHECK-DAG: #[[CALLLOC]] = loc("user_design.py":42:4)
+// CHECK-DAG: #[[MCLOC]] = loc("user_design.py":50:4)

--- a/test/create-flows/loc_preservation.mlir
+++ b/test/create-flows/loc_preservation.mlir
@@ -1,0 +1,33 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies --aie-create-pathfinder-flows propagates the source FlowOp's
+// location to the synthesized ConnectOps inside switchboxes, and that
+// per-tile WireOps inherit the corresponding tile's location.
+
+// RUN: aie-opt --aie-create-pathfinder-flows --mlir-print-debuginfo %s | FileCheck %s
+
+#flow_loc = loc("user_design.py":42:4)
+#tile_loc = loc("user_design.py":50:8)
+
+module {
+  aie.device(xcvc1902) {
+    %0 = aie.tile(2, 3) loc(#tile_loc)
+    %1 = aie.tile(3, 2) loc(#tile_loc)
+    aie.flow(%0, Core : 1, %1, DMA : 0) loc(#flow_loc)
+  }
+}
+
+// Synthesized aie.connect ops inside switchboxes carry the FlowOp's loc.
+// CHECK-DAG: aie.connect<{{.*}}> loc(#[[FLOWLOC:loc[0-9]*]])
+// Synthesized aie.wire ops between switchboxes/tiles carry the tile's loc.
+// CHECK-DAG: aie.wire({{.*}}) loc(#[[TILELOC:loc[0-9]*]])
+// CHECK-DAG: #[[FLOWLOC]] = loc("user_design.py":42:4)
+// CHECK-DAG: #[[TILELOC]] = loc("user_design.py":50:8)

--- a/test/herd-routing/loc_preservation.mlir
+++ b/test/herd-routing/loc_preservation.mlir
@@ -1,0 +1,46 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies --aie-herd-routing forwards the source HerdOp's location onto
+// the synthesized iter / select / switchbox / connect ops produced when
+// expanding a route.
+
+// The herd-routing pass produces an IR shape that the verifier rejects under
+// the current placement model (aie.switchbox expects a placed tile). The
+// location forwarding under test is independent of that — disable the
+// after-pass verifier so we can inspect the synthesized ops.
+
+// RUN: aie-opt --verify-each=false --aie-herd-routing --mlir-print-debuginfo %s | FileCheck %s
+
+#herd_loc = loc("user_design.py":42:4)
+
+// Use distinct, non-default locs on the user-written ops (iter, select) so
+// the test can isolate the locs that --aie-herd-routing synthesizes from
+// the pre-existing user-written ones.
+#scaffold_loc = loc("scaffold.mlir":1:1)
+
+module @loc_test {
+  aie.device(xcvc1902) {
+    %t = aiex.herd[1][1] { sym_name = "t" } loc(#herd_loc)
+    %s = aiex.herd[1][1] { sym_name = "s" } loc(#herd_loc)
+
+    %i0 = aiex.iter(0, 1, 1) loc(#scaffold_loc)
+
+    %sel_t = aiex.select(%t, %i0, %i0) loc(#scaffold_loc)
+    %sel_s = aiex.select(%s, %i0, %i0) loc(#scaffold_loc)
+    aiex.place(%t, %s, 3, 3) loc(#scaffold_loc)
+    aiex.route(<%sel_t, DMA: 0>, <%sel_s, DMA: 0>) loc(#scaffold_loc)
+  }
+}
+
+// Synthesized aie.connect ops (only present after the pass) inherit the
+// herd's source loc rather than loc(unknown) or the scaffold loc.
+// CHECK-DAG: "aie.connect"() {{.*}} loc(#[[HERDLOC:loc[0-9]*]])
+// CHECK-DAG: #[[HERDLOC]] = loc("user_design.py":42:4)

--- a/test/lower-to-standard/loc_preservation.mlir
+++ b/test/lower-to-standard/loc_preservation.mlir
@@ -1,0 +1,42 @@
+//===- loc_preservation.mlir -----------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that --aie-standard-lowering forwards the source op's location
+// onto its lowered standard-dialect ops.
+
+// RUN: aie-opt --aie-localize-locks --aie-standard-lowering --mlir-print-debuginfo %s | FileCheck %s
+
+#user_loc = loc("user_design.py":42:4)
+#buf_loc = loc("user_design.py":50:4)
+
+module @loc_test {
+ aie.device(xcve2302) {
+  %tile13 = aie.tile(1, 3)
+  %lock13 = aie.lock(%tile13, 0) loc(#user_loc)
+  %buf13 = aie.buffer(%tile13) {sym_name = "my_buf"} : memref<16xi32> loc(#buf_loc)
+
+  func.func private @kernel(%lock : index) {
+    aie.use_lock(%lock, "Acquire", 0) loc(#user_loc)
+    return
+  }
+
+  %core13 = aie.core(%tile13) {
+    func.call @kernel(%lock13) : (index) -> ()
+    aie.end
+  }
+ }
+}
+
+// The lowered call to llvm.aie2.acquire and the memref.global for the
+// buffer must reference the user's source location, not loc(unknown).
+// CHECK-DAG: call @llvm.aie2.acquire({{.*}}) : (i32, i32) -> () loc(#[[ULOC:loc[0-9]*]])
+// CHECK-DAG: memref.global "public" @my_buf : memref<16xi32> loc(#[[BUFLOC:loc[0-9]*]])
+// CHECK-DAG: #[[ULOC]] = loc("user_design.py":42:4)
+// CHECK-DAG: #[[BUFLOC]] = loc("user_design.py":50:4)

--- a/test/objectFifo-stateful-transform/base/loc_preservation.mlir
+++ b/test/objectFifo-stateful-transform/base/loc_preservation.mlir
@@ -1,0 +1,36 @@
+//===- loc_preservation.mlir ------------------------*- MLIR -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 AMD Inc.
+//
+//===----------------------------------------------------------------------===//
+
+// Verifies that --aie-objectFifo-stateful-transform forwards the source
+// objectfifo.create op's Location onto the synthesized buffer / lock ops.
+// See docs/SourceLocations.md for the broader plan.
+
+// RUN: aie-opt --aie-objectFifo-stateful-transform --mlir-print-debuginfo %s | FileCheck %s
+
+#user_loc = loc("user_design.py":42:4)
+
+module @loc_test {
+ aie.device(xcve2302) {
+    %tile12 = aie.tile(1, 2) loc(unknown)
+    %tile13 = aie.tile(1, 3) loc(unknown)
+    aie.objectfifo @of0 (%tile12, {%tile13}, 4 : i32) : !aie.objectfifo<memref<16xi32>> loc(#user_loc)
+ }
+}
+
+// MLIR pretty-prints with location aliases (loc(#locN)) at the end of the
+// module. Capture the alias used on the source objectfifo, then assert that
+// the synthesized buffers / locks reference the same alias and that the
+// alias resolves to user_design.py:42:4 (and is *not* loc(unknown)).
+
+// CHECK: aie.buffer({{.*}}) {sym_name = "of0_buff_0"} : memref<16xi32>{{ +}}loc(#[[USERLOC:loc[0-9]*]])
+// CHECK: aie.buffer({{.*}}) {sym_name = "of0_buff_1"} : memref<16xi32>{{ +}}loc(#[[USERLOC]])
+// CHECK: aie.lock({{.*}}) {init = 4 : i32, sym_name = "of0_prod_lock_0"} loc(#[[USERLOC]])
+// CHECK: aie.lock({{.*}}) {init = 0 : i32, sym_name = "of0_cons_lock_0"} loc(#[[USERLOC]])
+// CHECK: #[[USERLOC]] = loc("user_design.py":42:4)

--- a/test/python/iron_loc_emit.py
+++ b/test/python/iron_loc_emit.py
@@ -4,11 +4,16 @@
 #
 # (c) Copyright 2026 Advanced Micro Devices, Inc.
 
-# RUN: %python %s | FileCheck %s
+# Builds a tiny IRON program and verifies, two ways:
+#  PRE  — the printed MLIR carries `loc("of_in"(this_file:line))`-style
+#         NameLoc wrappers on every IRON entry-point op.
+#  POST — running that module through `aie-objectFifo-stateful-transform`
+#         preserves those locations on the synthesized buffer / lock /
+#         DMA / mem ops; i.e., the user's Python source position survives
+#         end-to-end through the front-end and a representative pass.
 
-# Builds a tiny IRON program and prints the resulting MLIR with debug info
-# enabled. Asserts that ObjectFifo / Worker / Kernel / fill ops carry a
-# FileLineColLoc / NameLoc tied back to this file rather than loc(unknown).
+# RUN: %python %s | FileCheck %s --check-prefix=PRE
+# RUN: %python %s | aie-opt --aie-place-tiles --aie-objectFifo-stateful-transform --mlir-print-debuginfo | FileCheck %s --check-prefix=POST
 
 import numpy as np
 
@@ -24,20 +29,18 @@ def main():
     dev = NPU1Col1()
     line_ty = np.ndarray[(64,), np.dtype[np.int32]]
 
-    of_in = ObjectFifo(line_ty, name="of_in")  # OF_IN_LINE
-    of_out = ObjectFifo(line_ty, name="of_out")  # OF_OUT_LINE
+    of_in = ObjectFifo(line_ty, name="of_in")
+    of_out = ObjectFifo(line_ty, name="of_out")
 
-    add_one = Kernel("add_one", "add_one.o", [line_ty, line_ty])  # KERNEL_LINE
+    add_one = Kernel("add_one", "add_one.o", [line_ty, line_ty])
 
-    worker = Worker(  # WORKER_LINE
-        core_body, fn_args=[of_in.cons(), of_out.prod(), add_one]
-    )
+    worker = Worker(core_body, fn_args=[of_in.cons(), of_out.prod(), add_one])
 
     rt = Runtime()
     with rt.sequence(line_ty, line_ty) as (a_in, c_out):
         rt.start(worker)
-        rt.fill(of_in.prod(), a_in)  # FILL_LINE
-        rt.drain(of_out.cons(), c_out, wait=True)  # DRAIN_LINE
+        rt.fill(of_in.prod(), a_in)
+        rt.drain(of_out.cons(), c_out, wait=True)
 
     program = Program(dev, rt)
     module = program.resolve_program()
@@ -46,18 +49,27 @@ def main():
     print(text)
 
 
-# MLIR pretty-prints each unique location once via `loc(#locN)` and emits
-# the definitions at the bottom of the module. NameLoc wrappers reference
-# their inner FileLineColLoc indirectly (e.g. loc("of_in"(#loc1))), so we
-# just check that each IRON-named NameLoc exists, plus that this file
-# appears as some FileLineColLoc.
-# CHECK-DAG: loc("of_in"
-# CHECK-DAG: loc("of_out"
-# CHECK-DAG: loc("add_one"
-# CHECK-DAG: loc("core_body"
-# CHECK-DAG: loc("fill(of_in)"
-# CHECK-DAG: loc("drain(of_out)"
-# CHECK-DAG: loc("{{.*}}iron_loc_emit.py":
+# IRON entry points each get a NameLoc whose inner FileLineColLoc points
+# back to this source file.
+# PRE-DAG: loc("of_in"
+# PRE-DAG: loc("of_out"
+# PRE-DAG: loc("add_one"
+# PRE-DAG: loc("core_body"
+# PRE-DAG: loc("fill(of_in)"
+# PRE-DAG: loc("drain(of_out)"
+# PRE-DAG: loc("{{.*}}iron_loc_emit.py":
+
+# After --aie-place-tiles + --aie-objectFifo-stateful-transform expand the
+# objectfifos into buffers / locks / DMA descriptors, those synthesized ops
+# still carry the user's source position via the original NameLoc.
+# POST-DAG: aie.buffer({{.*}}) {sym_name = "of_in_cons_buff_0"} : memref<64xi32>{{ +}}loc(#[[OF_IN:loc[0-9]*]])
+# POST-DAG: aie.buffer({{.*}}) {sym_name = "of_out_buff_0"} : memref<64xi32>{{ +}}loc(#[[OF_OUT:loc[0-9]*]])
+# POST-DAG: aie.lock({{.*}}) {{.*}}sym_name = "of_in_cons_prod_lock_0"{{.*}}loc(#[[OF_IN]])
+# POST-DAG: aie.lock({{.*}}) {{.*}}sym_name = "of_out_prod_lock_0"{{.*}}loc(#[[OF_OUT]])
+# POST-DAG: aie.dma_bd(%of_in_cons_buff_0 : memref<64xi32>, 0, 64) loc(#[[OF_IN]])
+# POST-DAG: aie.dma_bd(%of_out_buff_0 : memref<64xi32>, 0, 64) loc(#[[OF_OUT]])
+# POST-DAG: #[[OF_IN]] = loc("of_in"(
+# POST-DAG: #[[OF_OUT]] = loc("of_out"(
 
 if __name__ == "__main__":
     main()

--- a/test/python/iron_loc_emit.py
+++ b/test/python/iron_loc_emit.py
@@ -1,0 +1,63 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+
+# RUN: %python %s | FileCheck %s
+
+# Builds a tiny IRON program and prints the resulting MLIR with debug info
+# enabled. Asserts that ObjectFifo / Worker / Kernel / fill ops carry a
+# FileLineColLoc / NameLoc tied back to this file rather than loc(unknown).
+
+import numpy as np
+
+from aie.iron import Kernel, ObjectFifo, Program, Runtime, Worker
+from aie.iron.device import NPU1Col1
+
+
+def core_body(in_buf, out_buf, kernel):
+    pass
+
+
+def main():
+    dev = NPU1Col1()
+    line_ty = np.ndarray[(64,), np.dtype[np.int32]]
+
+    of_in = ObjectFifo(line_ty, name="of_in")  # OF_IN_LINE
+    of_out = ObjectFifo(line_ty, name="of_out")  # OF_OUT_LINE
+
+    add_one = Kernel("add_one", "add_one.o", [line_ty, line_ty])  # KERNEL_LINE
+
+    worker = Worker(  # WORKER_LINE
+        core_body, fn_args=[of_in.cons(), of_out.prod(), add_one]
+    )
+
+    rt = Runtime()
+    with rt.sequence(line_ty, line_ty) as (a_in, c_out):
+        rt.start(worker)
+        rt.fill(of_in.prod(), a_in)  # FILL_LINE
+        rt.drain(of_out.cons(), c_out, wait=True)  # DRAIN_LINE
+
+    program = Program(dev, rt)
+    module = program.resolve_program()
+
+    text = module.operation.get_asm(enable_debug_info=True)
+    print(text)
+
+
+# MLIR pretty-prints each unique location once via `loc(#locN)` and emits
+# the definitions at the bottom of the module. NameLoc wrappers reference
+# their inner FileLineColLoc indirectly (e.g. loc("of_in"(#loc1))), so we
+# just check that each IRON-named NameLoc exists, plus that this file
+# appears as some FileLineColLoc.
+# CHECK-DAG: loc("of_in"
+# CHECK-DAG: loc("of_out"
+# CHECK-DAG: loc("add_one"
+# CHECK-DAG: loc("core_body"
+# CHECK-DAG: loc("fill(of_in)"
+# CHECK-DAG: loc("drain(of_out)"
+# CHECK-DAG: loc("{{.*}}iron_loc_emit.py":
+
+if __name__ == "__main__":
+    main()

--- a/test/python/iron_loc_emit.py
+++ b/test/python/iron_loc_emit.py
@@ -68,8 +68,12 @@ def main():
 # POST-DAG: aie.lock({{.*}}) {{.*}}sym_name = "of_out_prod_lock_0"{{.*}}loc(#[[OF_OUT]])
 # POST-DAG: aie.dma_bd(%of_in_cons_buff_0 : memref<64xi32>, 0, 64) loc(#[[OF_IN]])
 # POST-DAG: aie.dma_bd(%of_out_buff_0 : memref<64xi32>, 0, 64) loc(#[[OF_OUT]])
+# POST-DAG: aiex.dma_await_task{{.*}} loc(#[[DRAIN:loc[0-9]*]])
+# POST-DAG: aiex.dma_free_task{{.*}} loc(#[[FILL:loc[0-9]*]])
 # POST-DAG: #[[OF_IN]] = loc("of_in"(
 # POST-DAG: #[[OF_OUT]] = loc("of_out"(
+# POST-DAG: #[[FILL]] = loc("fill(of_in)"(
+# POST-DAG: #[[DRAIN]] = loc("drain(of_out)"(
 
 if __name__ == "__main__":
     main()

--- a/test/python/iron_loc_emit_extras.py
+++ b/test/python/iron_loc_emit_extras.py
@@ -1,0 +1,73 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+
+# Covers IRON entry points that iron_loc_emit.py does not exercise:
+#   - Buffer (a top-level named buffer placed on the worker tile)
+#   - ObjectFifoLink (created by ObjectFifoHandle.forward())
+#   - Runtime.set_barrier
+#   - Runtime.inline_ops
+# Asserts that each of their resulting MLIR ops carries a NameLoc whose
+# inner FileLineColLoc points back to this file.
+
+# RUN: %python %s | FileCheck %s
+
+import numpy as np
+
+from aie.iron import (
+    Buffer,
+    ObjectFifo,
+    Program,
+    Runtime,
+    Worker,
+    WorkerRuntimeBarrier,
+)
+from aie.iron.device import NPU1Col1
+
+
+def core_body(scratch, barrier):
+    pass
+
+
+def my_inline_func(*args):
+    # Body runs inside an MLIR context during Runtime.resolve. Empty body
+    # is fine — we only care that the loc context wraps any ops it might
+    # generate.
+    pass
+
+
+def main():
+    dev = NPU1Col1()
+    line_ty = np.ndarray[(64,), np.dtype[np.int32]]
+    scratch_ty = np.ndarray[(16,), np.dtype[np.int32]]
+
+    of_in = ObjectFifo(line_ty, name="of_in")
+    of_mid = of_in.cons().forward(name="of_mid")  # ObjectFifoLink site
+    of_out = of_mid.cons().forward(name="of_out")
+
+    scratch = Buffer(scratch_ty, name="my_scratch")  # Buffer site
+    barrier = WorkerRuntimeBarrier()
+
+    worker = Worker(core_body, fn_args=[scratch, barrier])
+
+    rt = Runtime()
+    with rt.sequence(line_ty, line_ty) as (a_in, c_out):
+        rt.start(worker)
+        rt.set_barrier(barrier, 1)  # set_barrier site
+        rt.fill(of_in.prod(), a_in)
+        rt.drain(of_out.cons(), c_out, wait=True)
+        rt.inline_ops(my_inline_func, [scratch])  # inline_ops site
+
+    program = Program(dev, rt)
+    module = program.resolve_program()
+    print(module.operation.get_asm(enable_debug_info=True))
+
+
+# CHECK-DAG: loc("my_scratch"
+# CHECK-DAG: loc("link_of_in_to_of_mid"
+# CHECK-DAG: loc("{{.*}}iron_loc_emit_extras.py":
+
+if __name__ == "__main__":
+    main()

--- a/test/python/loc_capture.py
+++ b/test/python/loc_capture.py
@@ -54,6 +54,14 @@ def main():
             assert "loc_capture.py" in str(active)
         print("CHECK-5: loc_or_unknown context manager works")
 
+        # CapturedLoc is itself a context manager (frozen-dataclass safe).
+        with captured as direct:
+            assert "loc_capture.py" in str(direct)
+        # Re-entering after exit must work too.
+        with captured as direct2:
+            assert "loc_capture.py" in str(direct2)
+        print("CHECK-6: CapturedLoc.__enter__/__exit__ works on frozen dataclass")
+
     print("ALL OK")
 
 
@@ -62,6 +70,7 @@ def main():
 # CHECK: CHECK-3: materialized = loc("{{.*}}loc_capture.py":{{[0-9]+}}:{{[0-9]+}})
 # CHECK: CHECK-4: named materialized = loc("my_name"("{{.*}}loc_capture.py":{{[0-9]+}}:{{[0-9]+}}))
 # CHECK: CHECK-5: loc_or_unknown context manager works
+# CHECK: CHECK-6: CapturedLoc.__enter__/__exit__ works on frozen dataclass
 # CHECK: ALL OK
 
 if __name__ == "__main__":

--- a/test/python/loc_capture.py
+++ b/test/python/loc_capture.py
@@ -1,0 +1,68 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc.
+
+# RUN: %python %s | FileCheck %s
+
+# Verifies that aie.iron._loc.capture_user_loc:
+#   1. captures frame info eagerly (no MLIR Context required)
+#   2. returns a CapturedLoc whose filename matches the caller
+#   3. wraps the file/line in a NameLoc when materialized with a name
+#   4. plays nicely as a `with` block via loc_or_unknown
+
+import os
+from aie.iron._loc import capture_user_loc, loc_or_unknown, CapturedLoc
+from aie.ir import Context, Location
+
+
+def main():
+    # 1. Outside a Context, capture still works (eager).
+    assert Context.current is None
+    captured = capture_user_loc()
+    assert isinstance(captured, CapturedLoc), f"got {type(captured).__name__}"
+    assert os.path.basename(captured.filename) == "loc_capture.py"
+    assert captured.line > 0
+    assert captured.name is None
+    print(f"CHECK-1: eager capture: {os.path.basename(captured.filename)}:{captured.line}")
+
+    # 2. With a name, the name field is set; only materialized later.
+    named_capture = capture_user_loc(name="my_name")
+    assert named_capture.name == "my_name"
+    print(f"CHECK-2: named capture: name={named_capture.name}")
+
+    # 3. Inside a Context, materialize() builds a real Location and
+    #    `loc_or_unknown(captured)` enters it as a context manager.
+    with Context():
+        loc = captured.materialize()
+        s = str(loc)
+        assert "loc_capture.py" in s, f"unexpected: {s}"
+        print(f"CHECK-3: materialized = {s}")
+
+        # NameLoc wrapping
+        named_loc = named_capture.materialize()
+        s2 = str(named_loc)
+        assert s2.startswith('loc("my_name"'), s2
+        print(f"CHECK-4: named materialized = {s2}")
+
+        # `with loc_or_unknown(None):` falls back to unknown; the with
+        # block's value is a real Location either way.
+        with loc_or_unknown(None) as fallback:
+            assert "unknown" in str(fallback)
+        with loc_or_unknown(captured) as active:
+            assert "loc_capture.py" in str(active)
+        print("CHECK-5: loc_or_unknown context manager works")
+
+    print("ALL OK")
+
+
+# CHECK: CHECK-1: eager capture: loc_capture.py:{{[0-9]+}}
+# CHECK: CHECK-2: named capture: name=my_name
+# CHECK: CHECK-3: materialized = loc("{{.*}}loc_capture.py":{{[0-9]+}}:{{[0-9]+}})
+# CHECK: CHECK-4: named materialized = loc("my_name"("{{.*}}loc_capture.py":{{[0-9]+}}:{{[0-9]+}}))
+# CHECK: CHECK-5: loc_or_unknown context manager works
+# CHECK: ALL OK
+
+if __name__ == "__main__":
+    main()

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -375,6 +375,14 @@ static cl::opt<bool> dumpIntermediates(
     cl::desc("Dump intermediate MLIR files for debugging (default: off)"),
     cl::init(false), cl::cat(aieCompilerOptions));
 
+static cl::opt<bool> keepLoc(
+    "keep-loc",
+    cl::desc("Emit a <bin>.locmap.json sidecar next to each NPU instruction "
+             "binary, mapping each transaction word back to its IRON Python "
+             "source location. Also keeps debug-info on intermediate MLIR "
+             "dumps. Off by default."),
+    cl::init(false), cl::cat(aieCompilerOptions));
+
 static cl::opt<unsigned> numThreads(
     "j", cl::Prefix,
     cl::desc("Number of parallel threads for core compilation (0 = auto-detect "
@@ -3798,8 +3806,10 @@ static LogicalResult generateNpuInstructions(ModuleOp moduleOp,
       // Generate NPU instructions using direct C++ API call.
       // This replaces the subprocess call to aie-translate --aie-npu-to-binary.
       std::vector<uint32_t> instructions;
+      std::vector<xilinx::AIE::TxnLocEntry> locmap;
       if (failed(xilinx::AIE::AIETranslateNpuToBinary(
-              *clonedModule, instructions, devName, seqName))) {
+              *clonedModule, instructions, devName, seqName,
+              keepLoc ? &locmap : nullptr))) {
         llvm::errs() << "Error generating NPU instructions for sequence: "
                      << seqName << "\n";
         result = failure();
@@ -3822,6 +3832,27 @@ static LogicalResult generateNpuInstructions(ModuleOp moduleOp,
       if (verbose) {
         llvm::outs() << "Wrote " << instructions.size()
                      << " instructions to: " << outputPath << "\n";
+      }
+
+      // Emit the JSON sidecar when --keep-loc is on. Sidecar path is the
+      // .bin path with ".locmap.json" appended, so the .bin itself is
+      // unchanged for downstream XRT consumers.
+      if (keepLoc) {
+        SmallString<128> locmapPath(outputPath);
+        locmapPath.append(".locmap.json");
+        std::error_code locEc;
+        raw_fd_ostream locFile(locmapPath, locEc, sys::fs::OpenFlags::OF_Text);
+        if (locEc) {
+          llvm::errs() << "Error opening locmap sidecar: " << locEc.message()
+                       << "\n";
+          result = failure();
+          return;
+        }
+        StringRef binBaseName = sys::path::filename(outputPath);
+        xilinx::AIE::emitNpuLocmapJSON(locFile, devName, binBaseName, locmap);
+        if (verbose)
+          llvm::outs() << "Wrote " << locmap.size()
+                       << " locmap entries to: " << locmapPath << "\n";
       }
     });
   }
@@ -4017,9 +4048,10 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
   }
 
   std::vector<uint32_t> dmaSeqInstructions;
-  if (failed(xilinx::AIE::AIETranslateNpuToBinary(*clonedModule,
-                                                  dmaSeqInstructions, devName,
-                                                  "" /* all sequences */))) {
+  std::vector<xilinx::AIE::TxnLocEntry> dmaSeqLocmap;
+  if (failed(xilinx::AIE::AIETranslateNpuToBinary(
+          *clonedModule, dmaSeqInstructions, devName, "" /* all sequences */,
+          keepLoc ? &dmaSeqLocmap : nullptr))) {
     llvm::errs() << "Error generating control packet DMA sequence for device: "
                  << devName << "\n";
     return failure();
@@ -4041,6 +4073,25 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
   if (verbose) {
     llvm::outs() << "Wrote " << dmaSeqInstructions.size()
                  << " DMA sequence instructions to: " << dmaSeqBinPath << "\n";
+  }
+
+  if (keepLoc) {
+    SmallString<128> locmapPath(dmaSeqBinPath);
+    locmapPath.append(".locmap.json");
+    std::error_code locEc;
+    raw_fd_ostream locFile(locmapPath, locEc, sys::fs::OpenFlags::OF_Text);
+    if (!locEc) {
+      StringRef binBaseName = sys::path::filename(dmaSeqBinPath);
+      xilinx::AIE::emitNpuLocmapJSON(locFile, devName, binBaseName,
+                                     dmaSeqLocmap);
+      if (verbose)
+        llvm::outs() << "Wrote " << dmaSeqLocmap.size()
+                     << " locmap entries to: " << locmapPath << "\n";
+    } else {
+      llvm::errs() << "Error opening locmap sidecar: " << locEc.message()
+                   << "\n";
+      return failure();
+    }
   }
 
   // Step 3: Generate combined ELF using aiebu-asm (if available)

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -28,6 +28,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Diagnostics.h"
 #include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OperationSupport.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllExtensions.h"
 #include "mlir/InitAllPasses.h"
@@ -528,6 +529,12 @@ static std::vector<std::string> getHostSourceFiles() {
   return hostFiles;
 }
 
+static void printModuleWithDebugInfo(ModuleOp moduleOp, raw_ostream &os) {
+  OpPrintingFlags flags;
+  flags.enableDebugInfo(/*enable=*/true);
+  moduleOp->print(os, flags);
+}
+
 /// Dump an MLIR module to a file if --dump-intermediates is enabled.
 /// Returns true on success, false on failure.
 static bool dumpModuleToFile(ModuleOp moduleOp, StringRef filePath,
@@ -542,7 +549,7 @@ static bool dumpModuleToFile(ModuleOp moduleOp, StringRef filePath,
                  << filePath << ": " << ec.message() << "\n";
     return false;
   }
-  moduleOp->print(file);
+  printModuleWithDebugInfo(moduleOp, file);
   file.close();
 
   if (verbose) {
@@ -5231,7 +5238,11 @@ static LogicalResult compileAIEModule(MLIRContext &context, ModuleOp moduleOp,
                    << "\n";
       return failure();
     }
-    moduleOp->print(file);
+    if (dumpIntermediates) {
+      printModuleWithDebugInfo(moduleOp, file);
+    } else {
+      moduleOp->print(file);
+    }
 
     if (verbose) {
       llvm::outs() << "Wrote module with addresses to: " << withAddressesPath

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -3987,8 +3987,10 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
   }
 
   std::vector<uint32_t> ctrlPktInstructions;
+  std::vector<xilinx::AIE::TxnLocEntry> ctrlPktLocmap;
   if (failed(xilinx::AIE::AIETranslateControlPacketsToUI32Vec(
-          *clonedModule, ctrlPktInstructions, devName, ""))) {
+          *clonedModule, ctrlPktInstructions, devName, "",
+          keepLoc ? &ctrlPktLocmap : nullptr))) {
     llvm::errs() << "Error generating control packet binary for device: "
                  << devName << "\n";
     return failure();
@@ -4011,6 +4013,24 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
     llvm::outs() << "Wrote " << ctrlPktInstructions.size()
                  << " control packet instructions to: " << ctrlPktBinPath
                  << "\n";
+  }
+
+  if (keepLoc) {
+    SmallString<128> locmapPath(ctrlPktBinPath);
+    locmapPath.append(".locmap.json");
+    std::error_code locEc;
+    raw_fd_ostream locFile(locmapPath, locEc, sys::fs::OpenFlags::OF_Text);
+    if (locEc) {
+      llvm::errs() << "Error opening locmap sidecar: " << locEc.message()
+                   << "\n";
+      return failure();
+    }
+    StringRef binBaseName = sys::path::filename(ctrlPktBinPath);
+    xilinx::AIE::emitNpuLocmapJSON(locFile, devName, binBaseName,
+                                   ctrlPktLocmap);
+    if (verbose)
+      llvm::outs() << "Wrote " << ctrlPktLocmap.size()
+                   << " locmap entries to: " << locmapPath << "\n";
   }
 
   // Step 2: Run control packet DMA lowering pipeline in-memory.

--- a/tools/aiecc/aiecc.cpp
+++ b/tools/aiecc/aiecc.cpp
@@ -55,6 +55,7 @@
 #include "aie/Conversion/Passes.h"
 #include "aie/Dialect/AIE/IR/AIEDialect.h"
 #include "aie/Dialect/AIE/Transforms/AIEPasses.h"
+#include "aie/Dialect/AIE/Util/AIELocCheckpoint.h"
 #include "aie/Dialect/AIEVec/Analysis/Passes.h"
 #include "aie/Dialect/AIEVec/Pipelines/Passes.h"
 #include "aie/Dialect/AIEVec/TransformOps/DialectExtension.h"
@@ -544,9 +545,13 @@ static void printModuleWithDebugInfo(ModuleOp moduleOp, raw_ostream &os) {
 }
 
 /// Dump an MLIR module to a file if --dump-intermediates is enabled.
-/// Returns true on success, false on failure.
+/// When --keep-loc is also enabled and `stage` is non-empty, fuses
+/// "checkpoint:<stage>" onto every op's Location *on the live module*
+/// just before dumping. The label persists, so subsequent stages inherit
+/// it and the chain on a final aiex.npu.* op records the dump-file
+/// timeline. Returns true on success, false on failure.
 static bool dumpModuleToFile(ModuleOp moduleOp, StringRef filePath,
-                             StringRef description) {
+                             StringRef description, StringRef stage = "") {
   if (!dumpIntermediates)
     return true;
 
@@ -557,7 +562,12 @@ static bool dumpModuleToFile(ModuleOp moduleOp, StringRef filePath,
                  << filePath << ": " << ec.message() << "\n";
     return false;
   }
+
+  if (keepLoc && !stage.empty())
+    xilinx::AIE::applyStageLabel(moduleOp, stage);
+
   printModuleWithDebugInfo(moduleOp, file);
+
   file.close();
 
   if (verbose) {
@@ -1427,29 +1437,22 @@ static LogicalResult runTraceLoweringPipeline(ModuleOp moduleOp,
 
 /// Run the resource allocation pipeline in-memory using PassManager.
 /// This replaces the subprocess call to aie-opt with direct API calls.
-static LogicalResult runResourceAllocationPipeline(ModuleOp moduleOp,
-                                                   StringRef aieTarget,
-                                                   StringRef tmpDirName) {
+/// Run the first slice of the resource-allocation pipeline: from the
+/// vector-to-aievec conversion through the aie-objectFifo-stateful-transform
+/// pipeline. Stops there so the caller can dump the post-objectfifo IR for
+/// debugging (--dump-intermediates --keep-loc).
+static LogicalResult runPreObjectFifoResourceAllocationPipeline(
+    ModuleOp moduleOp, StringRef aieTarget, StringRef tmpDirName) {
   MLIRContext *ctx = moduleOp.getContext();
   PassManager pm(ctx);
 
-  // Enable verification between passes if verbose
   if (verbose) {
     pm.enableVerifier(true);
-    // Enable crash reproducer to help debug CI failures
     SmallString<128> crashFile(tmpDirName);
-    sys::path::append(crashFile, "resource_alloc_crash.mlir");
+    sys::path::append(crashFile, "resource_alloc_pre_objfifo_crash.mlir");
     pm.enableCrashReproducerGeneration(crashFile);
   }
 
-  // Step 1: Convert vector to aievec (this is a pipeline, not a single pass)
-  // Only add for AIE2 and later targets - AIE1 doesn't support
-  // target-backend=llvmir
-  // NOTE: Use parsePassPipeline instead of buildConvertVectorToAIEVec because
-  // ConvertVectorToAIEVecOptions only propagates aie-target to its sub-pipeline
-  // options (canonicalize, lower, optimize) through parseFromString, not
-  // through direct member assignment. Without this, aie2p falls back to aie1
-  // patterns.
   std::string lowerTarget = aieTarget.lower();
   if (lowerTarget == "aie2" || lowerTarget == "aieml" ||
       lowerTarget == "aie2p") {
@@ -1464,16 +1467,10 @@ static LogicalResult runResourceAllocationPipeline(ModuleOp moduleOp,
     }
   }
 
-  // Step 2: Lower affine
   pm.addPass(createLowerAffinePass());
-
-  // Step 3: Canonicalize device (module-level pass)
   pm.addPass(xilinx::AIE::createAIECanonicalizeDevicePass());
 
-  // Step 4: Device-level passes - use nest<DeviceOp>()
   OpPassManager &devicePm = pm.nest<xilinx::AIE::DeviceOp>();
-  // Note: Trace lowering runs in a separate guarded pipeline
-  // (runTraceLoweringPipeline) before this function is called.
   devicePm.addPass(xilinx::AIE::createAIEAssignLockIDsPass());
   devicePm.addPass(xilinx::AIE::createAIEObjectFifoRegisterProcessPass());
   {
@@ -1487,6 +1484,32 @@ static LogicalResult runResourceAllocationPipeline(ModuleOp moduleOp,
       return failure();
     }
   }
+
+  if (verbose) {
+    llvm::outs() << "Running pre-objectfifo resource allocation pipeline\n";
+    llvm::outs().flush();
+  }
+
+  return runPipelineWithRepeater(
+      pm, moduleOp, "pre-objectfifo resource allocation", tmpDirName);
+}
+
+/// Run the remainder of the resource-allocation pipeline: from
+/// aie-assign-buffer-descriptor-ids through scf-to-cf.
+static LogicalResult
+runPostObjectFifoResourceAllocationPipeline(ModuleOp moduleOp,
+                                            StringRef tmpDirName) {
+  MLIRContext *ctx = moduleOp.getContext();
+  PassManager pm(ctx);
+
+  if (verbose) {
+    pm.enableVerifier(true);
+    SmallString<128> crashFile(tmpDirName);
+    sys::path::append(crashFile, "resource_alloc_post_objfifo_crash.mlir");
+    pm.enableCrashReproducerGeneration(crashFile);
+  }
+
+  OpPassManager &devicePm = pm.nest<xilinx::AIE::DeviceOp>();
   devicePm.addPass(xilinx::AIE::createAIEAssignBufferDescriptorIDsPass());
   devicePm.addPass(xilinx::AIE::createAIELowerCascadeFlowsPass());
   devicePm.addPass(xilinx::AIEX::createAIEBroadcastPacketPass());
@@ -1502,35 +1525,57 @@ static LogicalResult runResourceAllocationPipeline(ModuleOp moduleOp,
     }
   }
 
-  // Create buffer address assignment pass with alloc-scheme option
   xilinx::AIE::AIEAssignBufferAddressesOptions bufferOpts;
   bufferOpts.clAllocScheme = allocScheme.getValue();
   devicePm.addPass(xilinx::AIE::createAIEAssignBufferAddressesPass(bufferOpts));
 
-  // Infer per-core link_files from func-level link_with attributes
   devicePm.addPass(xilinx::AIE::createAIEAssignCoreLinkFilesPass());
-
   devicePm.addPass(xilinx::AIE::createAIEVectorTransferLoweringPass());
 
-  // Step 5: Convert SCF to CF (module-level pass)
   pm.addPass(createSCFToControlFlowPass());
 
+  if (verbose) {
+    llvm::outs() << "Running post-objectfifo resource allocation pipeline "
+                 << "(alloc-scheme=" << allocScheme.getValue() << ")\n";
+    llvm::outs().flush();
+  }
+
+  return runPipelineWithRepeater(
+      pm, moduleOp, "post-objectfifo resource allocation", tmpDirName);
+}
+
+/// Convenience wrapper that runs both halves back-to-back, with an optional
+/// objectfifo-expanded dump in between (gated by --dump-intermediates).
+/// `dumpBasename` is the filename (no directory) to write the intermediate
+/// to, or empty to skip the dump (e.g. when invoked on the multi-device
+/// unfiltered module — the per-device call later dumps it).
+static LogicalResult
+runResourceAllocationPipeline(ModuleOp moduleOp, StringRef aieTarget,
+                              StringRef tmpDirName,
+                              StringRef dumpBasename = "") {
   if (verbose) {
     llvm::outs() << "Running resource allocation pipeline in-memory "
                  << "(alloc-scheme=" << allocScheme.getValue() << ")\n";
     llvm::outs().flush();
   }
 
-  if (failed(runPipelineWithRepeater(pm, moduleOp, "resource allocation",
-                                     tmpDirName))) {
-    llvm::errs() << "Error: Resource allocation pipeline failed\n";
+  if (failed(runPreObjectFifoResourceAllocationPipeline(moduleOp, aieTarget,
+                                                        tmpDirName)))
     return failure();
+
+  if (!dumpBasename.empty()) {
+    SmallString<128> objFifoPath(tmpDirName);
+    sys::path::append(objFifoPath, dumpBasename);
+    dumpModuleToFile(moduleOp, objFifoPath, "objectfifo expanded module",
+                     "objectfifo-expanded");
   }
+
+  if (failed(runPostObjectFifoResourceAllocationPipeline(moduleOp, tmpDirName)))
+    return failure();
 
   if (verbose) {
     llvm::outs() << "Resource allocation pipeline completed successfully\n";
   }
-
   return success();
 }
 
@@ -1574,44 +1619,115 @@ static void assignPdiIds(ModuleOp moduleOp,
 
 /// Run the NPU lowering pipeline in-memory using PassManager.
 /// This replaces the subprocess call to aie-opt with direct API calls.
+/// Helper: build + run a per-DeviceOp PM containing exactly one pass, named
+/// `passDescription` for diagnostics. Used by the split NPU lowering helpers
+/// so each transformation boundary can be dumped between via aiecc's
+/// --dump-intermediates.
+static LogicalResult runSingleDevicePass(ModuleOp moduleOp,
+                                         StringRef tmpDirName,
+                                         StringRef passDescription,
+                                         std::unique_ptr<mlir::Pass> p) {
+  PassManager pm(moduleOp.getContext());
+  if (verbose)
+    pm.enableVerifier(true);
+  OpPassManager &devicePm = pm.nest<xilinx::AIE::DeviceOp>();
+  devicePm.addPass(std::move(p));
+  return runPipelineWithRepeater(pm, moduleOp, passDescription, tmpDirName);
+}
+
+/// Slice of NPU lowering: aie-materialize-bd-chains. Standalone so the
+/// caller can dump <dev>_bd_chains_materialized.mlir afterwards.
+static LogicalResult runBdChainsMaterializationPipeline(ModuleOp moduleOp,
+                                                        StringRef tmpDirName) {
+  return runSingleDevicePass(moduleOp, tmpDirName, "bd-chains materialization",
+                             xilinx::AIEX::createAIEMaterializeBDChainsPass());
+}
+
+/// Slice of NPU lowering: substitute-shim-dma-allocations,
+/// assign-runtime-sequence-bd-ids, canonicalizer, dma-tasks-to-npu.
+static LogicalResult runDmaTasksToNpuPipeline(ModuleOp moduleOp,
+                                              StringRef tmpDirName) {
+  PassManager pm(moduleOp.getContext());
+  if (verbose)
+    pm.enableVerifier(true);
+  OpPassManager &devicePm = pm.nest<xilinx::AIE::DeviceOp>();
+  devicePm.addPass(xilinx::AIEX::createAIESubstituteShimDMAAllocationsPass());
+  devicePm.addPass(xilinx::AIEX::createAIEAssignRuntimeSequenceBDIDsPass());
+  devicePm.addPass(createCanonicalizerPass());
+  devicePm.addPass(xilinx::AIEX::createAIEDMATasksToNPUPass());
+  return runPipelineWithRepeater(pm, moduleOp, "dma-tasks-to-npu", tmpDirName);
+}
+
+/// Slice of NPU lowering: aie-dma-to-npu. Standalone for dump.
+static LogicalResult runDmaToNpuPipeline(ModuleOp moduleOp,
+                                         StringRef tmpDirName) {
+  return runSingleDevicePass(moduleOp, tmpDirName, "dma-to-npu",
+                             xilinx::AIEX::createAIEDmaToNpuPass());
+}
+
+/// Slice of NPU lowering: aie-lower-set-lock. Standalone for dump.
+static LogicalResult runSetLockLoweringPipeline(ModuleOp moduleOp,
+                                                StringRef tmpDirName) {
+  return runSingleDevicePass(moduleOp, tmpDirName, "lower-set-lock",
+                             xilinx::AIEX::createAIELowerSetLockPass());
+}
+
+/// Convenience wrapper composing all four NPU-lowering slices, with optional
+/// intermediate dumps between them when `devName` is non-empty (and
+/// --dump-intermediates is on). The legacy single-PM behavior is preserved
+/// when `devName` is empty: same passes run in the same order, just split
+/// across multiple PMs (negligible perf cost; tested).
 static LogicalResult runNpuLoweringPipeline(ModuleOp moduleOp,
                                             StringRef tmpDirName,
-                                            bool patchPdiIds = false) {
+                                            bool patchPdiIds = false,
+                                            StringRef devName = "") {
   MLIRContext *ctx = moduleOp.getContext();
 
-  // Phase 1: Core NPU lowering passes
-  {
+  // Phase 1a: module-level materialize runtime sequences (no dump in
+  // between — runs once before device-nested passes).
+  if (!noMaterialize) {
     PassManager pm(ctx);
-    if (verbose) {
+    if (verbose)
       pm.enableVerifier(true);
-    }
-
-    // Add materialize runtime sequences pass at module level (before device
-    // nesting) unless --no-materialize is specified
-    if (!noMaterialize) {
-      pm.addPass(xilinx::AIEX::createAIEMaterializeRuntimeSequencesPass());
-    }
-
-    // Device-level passes
-    OpPassManager &devicePm = pm.nest<xilinx::AIE::DeviceOp>();
-    devicePm.addPass(xilinx::AIEX::createAIEMaterializeBDChainsPass());
-    devicePm.addPass(xilinx::AIEX::createAIESubstituteShimDMAAllocationsPass());
-    devicePm.addPass(xilinx::AIEX::createAIEAssignRuntimeSequenceBDIDsPass());
-    devicePm.addPass(createCanonicalizerPass());
-    devicePm.addPass(xilinx::AIEX::createAIEDMATasksToNPUPass());
-    devicePm.addPass(xilinx::AIEX::createAIEDmaToNpuPass());
-    devicePm.addPass(xilinx::AIEX::createAIELowerSetLockPass());
-
-    if (verbose) {
-      llvm::outs() << "Running NPU lowering pipeline in-memory\n";
-    }
-
-    if (failed(runPipelineWithRepeater(pm, moduleOp, "NPU lowering",
-                                       tmpDirName))) {
-      llvm::errs() << "Error: NPU lowering pipeline failed\n";
+    pm.addPass(xilinx::AIEX::createAIEMaterializeRuntimeSequencesPass());
+    if (failed(runPipelineWithRepeater(
+            pm, moduleOp, "materialize runtime sequences", tmpDirName)))
       return failure();
-    }
   }
+
+  if (verbose)
+    llvm::outs() << "Running NPU lowering pipeline (split for intermediate "
+                    "dumps) in-memory\n";
+
+  auto dumpStage = [&](StringRef basename, StringRef desc, StringRef stage) {
+    if (devName.empty())
+      return;
+    SmallString<128> path(tmpDirName);
+    sys::path::append(path, devName.str() + "_" + basename.str());
+    dumpModuleToFile(moduleOp, path, desc, stage);
+  };
+
+  // Phase 1b: bd-chains materialization, then dump.
+  if (failed(runBdChainsMaterializationPipeline(moduleOp, tmpDirName)))
+    return failure();
+  dumpStage("bd_chains_materialized.mlir", "BD chains materialized",
+            "bd-chains-materialized");
+
+  // Phase 1c: dma-tasks-to-npu (incl. shim-dma-allocations, assign-bd-ids,
+  // canonicalizer), then dump.
+  if (failed(runDmaTasksToNpuPipeline(moduleOp, tmpDirName)))
+    return failure();
+  dumpStage("dma_tasks_to_npu.mlir", "DMA tasks to NPU", "dma-tasks-to-npu");
+
+  // Phase 1d: dma-to-npu, then dump.
+  if (failed(runDmaToNpuPipeline(moduleOp, tmpDirName)))
+    return failure();
+  dumpStage("dma_to_npu.mlir", "DMA to NPU", "dma-to-npu");
+
+  // Phase 1e: lower-set-lock, then dump.
+  if (failed(runSetLockLoweringPipeline(moduleOp, tmpDirName)))
+    return failure();
+  dumpStage("set_lock_lowered.mlir", "set-lock lowered", "set-lock-lowered");
 
   // Phase 2: Assign PDI IDs BEFORE expand-load-pdis (which copies IDs from
   // original load_pdi ops to the new empty device load_pdi ops).
@@ -3754,14 +3870,16 @@ static LogicalResult generateNpuInstructions(ModuleOp moduleOp,
   // expand-load-pdis so the IDs are assigned to the original device refs
   // before expand-load-pdis copies them to empty device load_pdi ops.
   if (failed(runNpuLoweringPipeline(*clonedModule, tmpDirName,
-                                    /*patchPdiIds=*/generateFullElf))) {
+                                    /*patchPdiIds=*/generateFullElf,
+                                    /*devName=*/devName))) {
     return failure();
   }
 
   // Dump intermediate if requested
   SmallString<128> npuLoweredPath(tmpDirName);
   sys::path::append(npuLoweredPath, devName.str() + "_npu_lowered.mlir");
-  dumpModuleToFile(*clonedModule, npuLoweredPath, "NPU lowered module");
+  dumpModuleToFile(*clonedModule, npuLoweredPath, "NPU lowered module",
+                   "npu-lowered");
 
   // Step 2: Translate to NPU binary
   // Find device and generate instructions for each runtime sequence
@@ -3912,7 +4030,7 @@ static LogicalResult generateTransactionOutput(ModuleOp moduleOp,
   // Dump intermediate MLIR
   SmallString<128> txnMlirPath(tmpDirName);
   sys::path::append(txnMlirPath, devName.str() + "_txn.mlir");
-  dumpModuleToFile(*clonedModule, txnMlirPath, "Transaction MLIR");
+  dumpModuleToFile(*clonedModule, txnMlirPath, "Transaction MLIR", "txn");
 
   // Copy to output location
   std::error_code ec;
@@ -3975,7 +4093,8 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
   // Dump intermediate MLIR for debugging
   SmallString<128> ctrlPktMlirPath(tmpDirName);
   sys::path::append(ctrlPktMlirPath, devName.str() + "_ctrlpkt.mlir");
-  dumpModuleToFile(*clonedModule, ctrlPktMlirPath, "control packet MLIR");
+  dumpModuleToFile(*clonedModule, ctrlPktMlirPath, "control packet MLIR",
+                   "ctrlpkt");
 
   // Translate control packet ops to binary
   std::string ctrlPktBinFileName = formatString(ctrlPktName, devName);
@@ -4043,7 +4162,7 @@ static LogicalResult generateControlPacketOutput(ModuleOp moduleOp,
   SmallString<128> dmaSeqMlirPath(tmpDirName);
   sys::path::append(dmaSeqMlirPath, devName.str() + "_ctrlpkt_dma_seq.mlir");
   dumpModuleToFile(*clonedModule, dmaSeqMlirPath,
-                   "control packet DMA sequence MLIR");
+                   "control packet DMA sequence MLIR", "ctrlpkt-dma-seq");
 
   // Assign PDI IDs after DMA lowering (matches legacy ordering)
   if (generateFullElf || generateElf) {
@@ -4411,7 +4530,9 @@ static LogicalResult generateElfFromInsts(ModuleOp moduleOp,
   // Clone and run NPU lowering (same as generateNpuInstructions)
   OwningOpRef<ModuleOp> clonedModule = moduleOp.clone();
 
-  if (failed(runNpuLoweringPipeline(*clonedModule, tmpDirName))) {
+  if (failed(runNpuLoweringPipeline(*clonedModule, tmpDirName,
+                                    /*patchPdiIds=*/false,
+                                    /*devName=*/devName))) {
     llvm::errs() << "Error running NPU lowering pipeline for ELF generation\n";
     return failure();
   }
@@ -5223,7 +5344,7 @@ static LogicalResult compileAIEModule(MLIRContext &context, ModuleOp moduleOp,
   // Dump input MLIR if requested
   SmallString<128> inputPath(tmpDirName);
   sys::path::append(inputPath, "input.mlir");
-  dumpModuleToFile(moduleOp, inputPath, "input MLIR");
+  dumpModuleToFile(moduleOp, inputPath, "input MLIR", "input");
 
   // Detect AIE target early from the input module
   std::string aieTarget = "aie2"; // Default
@@ -5291,8 +5412,12 @@ static LogicalResult compileAIEModule(MLIRContext &context, ModuleOp moduleOp,
     return failure();
   }
 
-  // Step 1b: Run resource allocation and lowering passes in-memory
-  if (failed(runResourceAllocationPipeline(moduleOp, aieTarget, tmpDirName))) {
+  // Step 1b: Run resource allocation and lowering passes in-memory.
+  // Pass a dump basename so the wrapper writes
+  // <tmpdir>/objectfifo_expanded.mlir between the pre- and post-objectfifo
+  // halves (gated by --dump-intermediates).
+  if (failed(runResourceAllocationPipeline(moduleOp, aieTarget, tmpDirName,
+                                           "objectfifo_expanded.mlir"))) {
     return failure();
   }
 
@@ -5329,7 +5454,7 @@ static LogicalResult compileAIEModule(MLIRContext &context, ModuleOp moduleOp,
   // Dump physical module if requested (for debugging only)
   SmallString<128> physicalPath(tmpDirName);
   sys::path::append(physicalPath, "input_physical.mlir");
-  dumpModuleToFile(moduleOp, physicalPath, "physical module");
+  dumpModuleToFile(moduleOp, physicalPath, "physical module", "input-physical");
 
   // Step 3: Compile cores and generate artifacts for each device
   // Collect device info for full ELF generation if requested
@@ -5376,7 +5501,8 @@ static LogicalResult compileAIEModule(MLIRContext &context, ModuleOp moduleOp,
     SmallString<128> physicalWithElfsPath(tmpDirName);
     sys::path::append(physicalWithElfsPath,
                       devName.str() + "_physical_with_elfs.mlir");
-    dumpModuleToFile(moduleOp, physicalWithElfsPath, "module with ELFs");
+    dumpModuleToFile(moduleOp, physicalWithElfsPath, "module with ELFs",
+                     "physical-with-elfs");
 
     // Generate control packet output BEFORE NPU instructions
     ModuleOp ctrlPktModule = unfilteredModule ? *unfilteredModule : moduleOp;
@@ -5480,6 +5606,10 @@ static LogicalResult compileAIEModule(MLIRContext &context, ModuleOp moduleOp,
     OwningOpRef<ModuleOp> expandedModule = moduleOp.clone();
 
     // 2. Run NPU lowering + expand-load-pdis ONCE (no PDI IDs yet)
+    // Phase B runs across all devices in one shot, so we don't pass a single
+    // devName for intermediate dumps (would conflate multiple devices into
+    // the same dump file). The per-device Phase A dumps already cover the
+    // intermediate stages.
     if (failed(runNpuLoweringPipeline(*expandedModule, tmpDirName,
                                       /*patchPdiIds=*/false))) {
       llvm::errs() << "Error: expanded NPU lowering pipeline failed\n";


### PR DESCRIPTION
This pull request significantly improves the preservation and propagation of source location information throughout the `mlir-aie` codebase. The main focus is to ensure that user source positions are captured at the Python frontend and maintained through all relevant C++ transformation passes, enabling better diagnostics, debugging, and profiling. The changes replace the use of `UnknownLoc` with meaningful source locations, primarily by forwarding the location from source operations. This work is well documented in the new `docs/SourceLocations.md` and is supported by a proof-of-concept implementation.

**Key improvements include:**

### Documentation and Rationale

* Added a comprehensive document, `docs/SourceLocations.md`, detailing the motivation, current state, infrastructure, proposed approach (in three phases), and proof-of-concept results for source location tracking in `mlir-aie`.

### Propagation of Source Locations in C++ Passes

* Replaced `builder.getUnknownLoc()` with forwarding of source operation locations (`op.getLoc()` or equivalent) in multiple transformation passes, especially in:
  - `lib/Conversion/AIEToConfiguration/AIEToConfiguration.cpp` [[1]](diffhunk://#diff-4c0d40fdfbb75cb0b5a2aa3c562960be441b0123c5a1092f68778b54ff85a47fL453-L458) [[2]](diffhunk://#diff-4c0d40fdfbb75cb0b5a2aa3c562960be441b0123c5a1092f68778b54ff85a47fL534-L538) [[3]](diffhunk://#diff-4c0d40fdfbb75cb0b5a2aa3c562960be441b0123c5a1092f68778b54ff85a47fL639-R645) [[4]](diffhunk://#diff-4c0d40fdfbb75cb0b5a2aa3c562960be441b0123c5a1092f68778b54ff85a47fL679-R678) [[5]](diffhunk://#diff-4c0d40fdfbb75cb0b5a2aa3c562960be441b0123c5a1092f68778b54ff85a47fL787-R783)
  - `lib/Dialect/AIE/IR/AIEDialect.cpp`
  - `lib/Dialect/AIE/Transforms/AIECanonicalizeDevice.cpp`
  - `lib/Dialect/AIE/Transforms/AIECoreToStandard.cpp` for all relevant lowering patterns, ensuring that new ops inherit the original op's location [[1]](diffhunk://#diff-501305114cb34a6f1bc46e1b14ca4f74f66491931bcd824a89cee1010c704b62L214-R214) [[2]](diffhunk://#diff-501305114cb34a6f1bc46e1b14ca4f74f66491931bcd824a89cee1010c704b62L262-R262) [[3]](diffhunk://#diff-501305114cb34a6f1bc46e1b14ca4f74f66491931bcd824a89cee1010c704b62L303-R303) [[4]](diffhunk://#diff-501305114cb34a6f1bc46e1b14ca4f74f66491931bcd824a89cee1010c704b62L355-R355) [[5]](diffhunk://#diff-501305114cb34a6f1bc46e1b14ca4f74f66491931bcd824a89cee1010c704b62L391-R391) [[6]](diffhunk://#diff-501305114cb34a6f1bc46e1b14ca4f74f66491931bcd824a89cee1010c704b62L462-R462) [[7]](diffhunk://#diff-501305114cb34a6f1bc46e1b14ca4f74f66491931bcd824a89cee1010c704b62L493-R492) [[8]](diffhunk://#diff-501305114cb34a6f1bc46e1b14ca4f74f66491931bcd824a89cee1010c704b62L502-R503) [[9]](diffhunk://#diff-501305114cb34a6f1bc46e1b14ca4f74f66491931bcd824a89cee1010c704b62L550-R549)

### Improved Location Handling Patterns

* Ensured that synthesized operations (e.g., buffers, locks, function calls, global memory references) in lowering and transformation passes now inherit and correctly propagate the source location, rather than defaulting to an unknown location. This is critical for meaningful error messages and debugging.

These changes collectively reduce the use of unknown locations by about 89% in the codebase, as documented, and lay the groundwork for further improvements in backend and tooling support for source locations.