### PR TITLE
test(mdv6): cover full-model multi-frame cache

### DIFF
--- a/programming_examples/ml/mdv6/run_full_model_multi_frame.lit
+++ b/programming_examples/ml/mdv6/run_full_model_multi_frame.lit
@@ -1,0 +1,22 @@
+// (c) Copyright 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// MDV6 32-core full-model multi-frame regression test.
+//
+// Bead: nd-fnjae3
+//
+// This exercises the video-stream path that repeatedly constructs and frees
+// the model. It catches regressions where fused-weight caches key on recycled
+// Python object ids, causing frame 2+ to reuse stale tensors.
+//
+// REQUIRES: ryzen_ai_npu2, peano, torch, mdv6_weights
+//
+// RUN: rm -rf test_stx_multi_frame
+// RUN: mkdir -p test_stx_multi_frame
+// RUN: cd test_stx_multi_frame
+//
+// Build the xclbins into this test's working directory so no generated
+// artifacts are written to the source tree.
+// RUN: env MDV6_BUILD_DIR=. %run_on_npu2% python3 %S/conv/build_multicore.py || true
+// RUN: env MDV6_BUILD_DIR=. %run_on_npu2% python3 %S/gemm_conv1x1/build_gemm_conv1x1.py
+// RUN: env MDV6_BUILD_DIR=. %run_on_npu2% python3 %S/test_full_model_mc.py --profile 3


### PR DESCRIPTION
## Purpose
Add regression coverage for the MDV6 multi-frame inference cache bug tracked by npu-dev bead nd-fnjae3. The test runs the existing full-model multicore path for three frames so object-id reuse and stale fused-weight cache hits are exercised in CI.

## Changed files
- `programming_examples/ml/mdv6/run_full_model_multi_frame.lit`: new lit wrapper that builds the MDV6 multicore/GEMM xclbins into a per-test work directory and runs `test_full_model_mc.py --profile 3`.

## Test evidence
- Local: `git diff --check origin/mdv6..HEAD` passed.
- Local NPU/perf: not run from the warden session per npu-dev runner policy.
- CI/HW: deferred to CI or the downstream npu-dev gitlink bump after this fork PR lands.

## Risk notes
Low source risk: test-only change. Runtime cost is non-trivial because it runs a three-frame full-model NPU path, so the downstream mdv6 PR should watch runner time, full-model correctness, and the perf baseline gate.

## Rollback notes
Revert this commit, or close the downstream npu-dev gitlink bump without merging.

Bead: nd-fnjae3
Variant: mdv6